### PR TITLE
Add a PR template specific for Helm charts

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/chart.md
+++ b/.github/PULL_REQUEST_TEMPLATE/chart.md
@@ -1,0 +1,44 @@
+# Chart
+
+## Description
+
+Describe your changes. 
+
+If the pull request contains a new chart, you should describe the service it provides, the origin of its image, and any other things that may be relevant.
+
+## Types of changes
+
+What types of changes does your code introduce to STACKn?
+
+- [ ] Hotfix (fixing a critical bug in production)
+- [ ] Bugfix
+- [ ] New chart
+- [ ] Documentation update
+
+## Checklist
+
+### Chart
+
+- [ ] The image is not running as root
+- [ ] The file system is read-only
+- [ ] The service account token is not mounted (not applicable if the token is required for the funtion of the pod)
+- [ ] A `readinessProbe` is included
+- [ ] NetworkPolicies are included to keep the network access to a minimum
+- [ ] Resource limits have been set (CPU, memory, and ephemeral storage), both a good estimate of the requested resources, and the maximum resources the pods may use 
+- [ ] A unique service account is created
+- [ ] Any sensitive data is stored in a `Secret`
+
+### General
+
+- [ ] I have included a link to the issue on GitHub or JIRA (if any)
+- [ ] I have included migration files (if there are changes to the model classes)
+- [ ] I have read the [CONTRIBUTING](https://github.com/scaleoutsystems/stackn/blob/master/CONTRIBUTING.md) doc
+- [ ] I have included tests to complement my changes
+- [ ] I have updated the related documentation (if necessary) 
+- [ ] I have updated the release notes (docs/releasenotes.md)
+- [ ] I have added a reviewer for this pull request
+- [ ] I have added myself as an author for this pull request
+
+## Further comments
+
+Anything else you think we should know before merging your code!

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,8 @@
 
 ## Description
 
+*If the PR contains a chart, use the [chart PR template](?expand=1&template=chart.md) instead.*
+
 Describe your changes here to communicate to the maintainers why we should accept this pull request. 
 If it fixes a bug or resolves a feature request, be sure to include a link to that issue.
 


### PR DESCRIPTION
## Status

- [X] Ready
- [ ] Draft
- [ ] Hold

## Description

An early version of a chart-specific PR template. Currently there is a checklist of some security-related issues that should be fixed in any new charts. It is intended to grow as I see what things are missing/often done wrong in the current charts.

The template will not replace the default one. Instead it will be available if you add the parameter `?template=chart.md` once you make it to the "Open a pull request" window. If there is already a parameter (`?key=val`) at the end of the url, you add `&template=chart.md` instead. The url will then be similar to `https://github.com/ScilifelabDataCentre/stackn/compare/main...ScilifelabDataCentre:stackn:dc-develop?template=chart.md`.

## Types of changes

What types of changes does your code introduce to STACKn?

- [ ] Hotfix (fixing a critical bug in production)
- [ ] Bugfix
- [ ] New feature
- [ ] Documentation update

- [X] Infrastructure update


## Checklist

_If you're unsure about any of the items below, don't hesitate to ask. We're here to help! 
This is simply a reminder of what we are going to look for before merging your code._

- [ ] This pull request is against **develop** branch (not applicable for hotfixes)
- [ ] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [ ] I have read the [CONTRIBUTING](https://github.com/scaleoutsystems/stackn/blob/master/CONTRIBUTING.md) doc
- [ ] I have included tests to complement my changes
- [ ] I have updated the related documentation (if necessary) 
- [ ] I have updated the release notes (docs/releasenotes.md)
- [ ] I have added a reviewer for this pull request
- [ ] I have added myself as an author for this pull request
