### PR TITLE
working mlflow

### DIFF
--- a/components/studio/charts/apps/mlflow-serve/chart/templates/deployment.yaml
+++ b/components/studio/charts/apps/mlflow-serve/chart/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
         {{ if eq .Values.model.type "model" }}
         args: ["-c", "mc config host add projminio $S3_ENDPOINT $S3_ACCESS_KEY_ID $S3_SECRET_ACCESS_KEY;mc cp projminio/$STACKN_MODEL_BUCKET/$STACKN_MODEL_FILE /models/model.tar.gz"]
         {{ else }}
-        args: ["-c", "mc config host add projminio $S3_ENDPOINT $S3_ACCESS_KEY_ID $S3_SECRET_ACCESS_KEY;mc cp -r projminio/$STACKN_MODEL_BUCKET/$STACKN_MODEL_PATH /models/"]
+        args: ["-c", "mc config host add projminio $S3_ENDPOINT $S3_ACCESS_KEY_ID $S3_SECRET_ACCESS_KEY;mc cp -r projminio/$STACKN_MODEL_BUCKET/ /models/"]
         {{ end }}
         volumeMounts:
         - name: model-vol
@@ -117,7 +117,7 @@ spec:
       {{ end }}
       - name: serve
         command: ["/bin/sh"]
-        args: ["-c", "mlflow models serve -m models/model -h 0.0.0.0"]
+        args: ["-c", model_path=$(find "/models" -type d -name "model" -print -quit); mlflow models serve -m $model_path --host 0.0.0.0 --port 5000] 
         resources:
           limits:
             cpu: {{ .Values.flavor.limits.cpu }}

--- a/components/studio/charts/apps/mlflow/chart/templates/deployment.yaml
+++ b/components/studio/charts/apps/mlflow/chart/templates/deployment.yaml
@@ -56,7 +56,7 @@ spec:
           mountPath: /etc/nginx
         - name: auth-vol
           mountPath: /auth
-      - image: scaleoutsystems/mlflow-server:latest
+      - image: ghcr.io/scilifelabdatacentre/serve-mlflow:latest
         imagePullPolicy: IfNotPresent
         name: mlflow
         env:
@@ -72,8 +72,8 @@ spec:
           value: {{ .Values.s3.secret_key }}
         ports:
         - containerPort: 5000
-        # command: ["/bin/sh"]
-        # args: ["-c", "mlflow server --host 0.0.0.0:5000"]
+        command: ["/bin/sh"]
+        args: ["-c", "mlflow server --host 0.0.0.0 --port 5000 --backend-store-uri ${BACKEND_STORE_URI} --default-artifact-root s3://${MLFLOW_BUCKET}/"]
         resources: {}
         volumeMounts:
         {{- range $key, $value := .Values.apps.volumeK8s }}


### PR DESCRIPTION
## Status

- [X] Ready
- [ ] Draft
- [ ] Hold

## Description
I've changed the `deployment.yaml` in the `mlflow` and `mlflow-serve` helm charts to use our new mlflow image. I've also updated the project fixture to use our own mlflow image (and our own jupyterlab image). 
I've tested this on a local deployment of Serve on microk8s and it works. 

However, the usage of MLFlow in serve i suboptimal. We use one deployment for hosting the MLFlow server which logs the model and all your experiments, but if we want to serve a specific model, we must do this in Serve, by creating a new model, and then spin up a new pod where we run the serving capability. This is not the intended use of MLFlow since this unlinks the server with model serving. This can be fixed at a later stage.  

## Types of changes

- [ ] Hotfix (fixing a critical bug in production)
- [ ] Bugfix
- [ X] New feature
- [ ] Documentation update