### PR TITLE
Ss 666 inform notebooks shut down

### DIFF
--- a/common/forms.py
+++ b/common/forms.py
@@ -104,7 +104,7 @@ class UserForm(BootstrapErrorFormMixin, UserCreationForm):
             "Use your <a "
             "href='https://www.uka.se/sa-fungerar-hogskolan/universitet-och-hogskolor/lista-over-"
             "universitet-hogskolor-och-enskilda-utbildningsanordnare'>"
-            "Swedish university</a> email address. If you are not affiliated with a Swedish university,"
+            "Swedish university</a> email address. If you are not affiliated with a Swedish university, "
             "your account request will be reviewed manually."
         ),
     )

--- a/static/js/form-helpers.js
+++ b/static/js/form-helpers.js
@@ -2,6 +2,8 @@ window.onload = (event) => {
     const email = document.getElementById('id_email');
     const choiceSelect = document.getElementById('id_affiliation');
     const request_account_field = document.getElementById('id_request_account_info');
+    const request_account_label = document.querySelector('label[for="id_why_account_needed"]');
+    const department_label = document.querySelector('label[for="id_department"]');
 
     const domainRegex = /^(?:[A-Z0-9](?:[\.A-Z0-9-]{0,61}[A-Z0-9])?\.)*?(uu|lu|gu|su|umu|liu|ki|kth|chalmers|ltu|hhs|slu|kau|lnu|oru|miun|mau|mdu|bth|fhs|gih|hb|du|hig|hh|hkr|his|hv|ju|sh)\.se$/i;
 
@@ -22,14 +24,17 @@ window.onload = (event) => {
             const domain = match[1];
             choiceSelect.value = domain;
             shouldHide = true;
+            department_label.classList.add('required');
         } else {
             choiceSelect.value = 'other';  // Reset to default or empty value
+            department_label.classList.remove('required');
         }
 
         if (shouldHide) {
             request_account_field.classList.add('hidden');
         } else {
             request_account_field.classList.remove('hidden');
+            request_account_label.classList.add('required');
         }
     }
 

--- a/templates/apps/create.html
+++ b/templates/apps/create.html
@@ -16,13 +16,15 @@
 <div class="row">
     <div class="col-12 mt-2 mb-4">
         {% if app.slug == 'customapp' %}
-        This form allows you to start hosting an app that fulfills certain requirements on SciLifeLab Serve (the app itself can be built on any framework). Please read our <a href="#">documentation page on custom apps</a> for the list of requirements and step-by-step instructions on deployment.
+        <p>This form allows you to start hosting an app that fulfills certain requirements on SciLifeLab Serve (the app itself can be built on any framework). Please read our <a href="#">documentation page on custom apps</a> for the list of requirements and step-by-step instructions on deployment.</p>
         {% elif app.slug == 'dashapp' %}
-        This form allows you to start hosting a Dash app at SciLifeLab Serve. Please read our <a href="#">documentation page on Dash apps</a> for step-by-step instructions.
+        <p>This form allows you to start hosting a Dash app at SciLifeLab Serve. Please read our <a href="#">documentation page on Dash apps</a> for step-by-step instructions.</p>
         {% elif app.slug in 'shinyapp,shinyproxyapp' %}
-        This form allows you to start hosting a Shiny app at SciLifeLab Serve. Please read our <a href="#">documentation page on Shiny apps</a> for step-by-step instructions.
-        {% else %}
-        [link to documentation to be added here]
+        <p>This form allows you to start hosting a Shiny app at SciLifeLab Serve. Please read our <a href="#">documentation page on Shiny apps</a> for step-by-step instructions.</p>
+        {% endif %}
+        {% if app.slug in 'jupyter-lab,rstudio,vscode' %}
+        <p>Note that <b>after 7 days the created {{ app.name }} instance will be deleted</b>, only the files saved in 'project-vol' will stay available.</p>
+        <p>Each {{ app.name }} instance can get access to the persistent volume (folder) associated with this project, called 'project-vol'. Please make sure to save all your data files, script files, output from computations, etc. inside 'project-vol'; the files located elsewhere can be deleted at any point. The files saved inside 'project-vol' will be available across all instances of {{ app.name }} (as well as other apps) within this project.</p>
         {% endif %}
     </div>
 </div>

--- a/templates/projects/overview.html
+++ b/templates/projects/overview.html
@@ -50,8 +50,7 @@
                 <h5 class="card-title mb-0">{{ objs.title }}</h5>
             </div>
             {% if objs.objs %}
-            <div class="no-footer mx-4 my-4">
-
+            <div class="no-footer mx-4 mt-4">
                 <table id=""
                     class="table table-hover my-0 no-footer table-bordered" role="grid">
                     <thead>
@@ -135,6 +134,9 @@
                         {% endfor %}
                     </tbody>
                 </table>
+            </div>
+            <div class="mx-4 mb-4 small text-muted">
+            *Note that all apps under Develop will be deleted 7 days after creation.
             </div>
             {% else %}
             <div class="h-100 p-4 d-flex align-items-center justify-content-center border-bottom">


### PR DESCRIPTION
## Description

This PR contains two minor changes. It solves the issue [SS-666](https://scilifelab.atlassian.net/browse/SS-666) - now there is a clear text saying that the notebooks will be removed after 7 days. It also solves issue [SS-673](https://scilifelab.atlassian.net/browse/SS-673) - now the conditionally required fields in the registration form get a red asterisk when they are required and otherwise do not get the asterisk.

## Checklist

_If you're unsure about any of the items below, don't hesitate to ask. We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] This pull request is against **develop** branch (not applicable for hotfixes)
- [x] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [x] I have included, reviewed and executed tests (unit and end2end) to complement my changes
- [ ] I have updated the related documentation (if necessary)
- [ ] I have updated the release notes (releasenotes.md)
- [x] I have added a reviewer for this pull request
- [x] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts