### PR TITLE
SS 693 ingress does not care if app is public or private

### DIFF
--- a/apps/tasks.py
+++ b/apps/tasks.py
@@ -203,7 +203,7 @@ def deploy_resource(instance_pk, action="create"):
     app_instance = AppInstance.objects.select_for_update().get(pk=instance_pk)
     status = AppStatus(appinstance=app_instance)
 
-    if action == "create":
+    if (action == "create") or (action == "update"):
         parameters = app_instance.parameters
         status.status_type = "Created"
         status.info = parameters["release"]
@@ -211,11 +211,6 @@ def deploy_resource(instance_pk, action="create"):
         # For backwards-compatibility with old ingress spec:
         if "ingress" not in parameters:
             parameters["ingress"] = dict()
-        try:
-            print("Ingress v1beta1: {}".format(settings.INGRESS_V1BETA1))
-            parameters["ingress"]["v1beta1"] = settings.INGRESS_V1BETA1
-        except:  # noqa E722 TODO: Add exception
-            pass
 
         app_instance.parameters = parameters
         print("App Instance paramenters: {}".format(app_instance))

--- a/charts/apps/custom-app/chart/templates/ingress.yaml
+++ b/charts/apps/custom-app/chart/templates/ingress.yaml
@@ -1,29 +1,3 @@
-{{ if .Values.ingress.v1beta1 }}
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: {{ .Release.Name }}-ingress
-  namespace: {{ .Values.namespace }}
-  labels:
-    io.kompose.service: {{ .Release.Name }}-ingress
-  annotations:
-    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?release={{ .Values.release }}"
-    nginx.ingress.kubernetes.io/auth-signin: "https://{{ .Values.global.domain }}/accounts/login/?next=$scheme%3A%2F%2F$host"
-    #nginx.ingress.kubernetes.io/auth-response-headers: X-Forwarded-Host
-spec:
-  rules:
-    - host: {{ .Release.Name }}.{{ .Values.global.domain }}
-      http:
-        paths:
-        - path: /
-          backend:
-            serviceName: {{ .Values.service.name }}
-            servicePort: {{ .Values.service.port }}
-  tls:
-    - secretName: {{ .Values.ingress.secretName }}
-      hosts:
-        - {{ .Values.global.domain }}
-{{ else }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -32,9 +6,10 @@ metadata:
   labels:
     io.kompose.service: {{ .Release.Name }}-ingress
   annotations:
+    {{ if ne .Values.permission "public" }}
     nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?release={{ .Values.release }}"
     nginx.ingress.kubernetes.io/auth-signin: "https://{{ .Values.global.domain }}/accounts/login/?next=$scheme%3A%2F%2F$host"
-    #nginx.ingress.kubernetes.io/auth-response-headers: X-Forwarded-Host
+    {{- end }}
 spec:
   rules:
     - host: {{ .Release.Name }}.{{ .Values.global.domain }}
@@ -51,4 +26,3 @@ spec:
     - secretName: {{ .Values.ingress.secretName }}
       hosts:
         - {{ .Values.global.domain }}
-{{- end }}

--- a/charts/apps/custom-app/chart/values.yaml
+++ b/charts/apps/custom-app/chart/values.yaml
@@ -20,7 +20,6 @@ imagePullSecrets:
   - name: regcred
 
 ingress:
-  v1beta1: false
   secretName: prod-ingress
   
 podSecurityContext:

--- a/charts/apps/dash/chart/templates/ingress.yaml
+++ b/charts/apps/dash/chart/templates/ingress.yaml
@@ -1,29 +1,3 @@
-{{ if .Values.ingress.v1beta1 }}
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: {{ .Release.Name }}-ingress
-  namespace: {{ .Values.namespace }}
-  labels:
-    io.kompose.service: {{ .Release.Name }}-ingress
-  annotations:
-    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?release={{ .Values.release }}"
-    nginx.ingress.kubernetes.io/auth-signin: "https://{{ .Values.global.domain }}/accounts/login/?next=$scheme%3A%2F%2F$host"
-    #nginx.ingress.kubernetes.io/auth-response-headers: X-Forwarded-Host
-spec:
-  rules:
-    - host: {{ .Release.Name }}.{{ .Values.global.domain }}
-      http:
-        paths:
-        - path: /
-          backend:
-            serviceName: {{ .Values.service.name }}
-            servicePort: {{ .Values.service.port }}
-  tls:
-    - secretName: {{ .Values.ingress.secretName }}
-      hosts:
-        - {{ .Values.global.domain }}
-{{ else }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -32,9 +6,10 @@ metadata:
   labels:
     io.kompose.service: {{ .Release.Name }}-ingress
   annotations:
+    {{ if ne .Values.permission "public" }}
     nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?release={{ .Values.release }}"
     nginx.ingress.kubernetes.io/auth-signin: "https://{{ .Values.global.domain }}/accounts/login/?next=$scheme%3A%2F%2F$host"
-    #nginx.ingress.kubernetes.io/auth-response-headers: X-Forwarded-Host
+    {{- end }}
 spec:
   rules:
     - host: {{ .Release.Name }}.{{ .Values.global.domain }}
@@ -51,4 +26,3 @@ spec:
     - secretName: {{ .Values.ingress.secretName }}
       hosts:
         - {{ .Values.global.domain }}
-{{- end }}

--- a/charts/apps/dash/chart/values.yaml
+++ b/charts/apps/dash/chart/values.yaml
@@ -20,7 +20,6 @@ imagePullSecrets:
   - name: regcred
 
 ingress:
-  v1beta1: false
   secretName: prod-ingress
 
 podSecurityContext:

--- a/charts/apps/pytorch-serve/chart/templates/ingress.yaml
+++ b/charts/apps/pytorch-serve/chart/templates/ingress.yaml
@@ -6,8 +6,10 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-body-size: "500m"
+    {{ if ne .Values.permission "public" }}
     nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?release={{ .Values.release }}"
     nginx.ingress.kubernetes.io/auth-signin: "https://{{ .Values.global.domain }}/accounts/login/?next=$scheme%3A%2F%2F$host"
+    {{- end }}
   name: {{ .Release.Name }}-ingress
   namespace: {{ .Values.namespace }}
 spec:

--- a/charts/apps/pytorch-serve/chart/values.yaml
+++ b/charts/apps/pytorch-serve/chart/values.yaml
@@ -46,7 +46,6 @@ imagePullSecrets:
   - name: regcred
 
 ingress:
-  v1beta1: false
 
 podSecurityContext:
   seccompProfile:

--- a/charts/apps/shiny/chart/templates/ingress.yaml
+++ b/charts/apps/shiny/chart/templates/ingress.yaml
@@ -1,29 +1,3 @@
-{{ if .Values.ingress.v1beta1 }}
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: {{ .Release.Name }}-ingress
-  namespace: {{ .Values.namespace }}
-  labels:
-    io.kompose.service: {{ .Release.Name }}-ingress
-  annotations:
-    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?release={{ .Values.release }}"
-    nginx.ingress.kubernetes.io/auth-signin: "https://{{ .Values.global.domain }}/accounts/login/?next=$scheme%3A%2F%2F$host"
-    #nginx.ingress.kubernetes.io/auth-response-headers: X-Forwarded-Host
-spec:
-  rules:
-    - host: {{ .Release.Name }}.{{ .Values.global.domain }}
-      http:
-        paths:
-        - path: /
-          backend:
-            serviceName: {{ .Values.service.name }}
-            servicePort: {{ .Values.service.port }}
-  tls:
-    - secretName: {{ .Values.ingress.secretName }}
-      hosts:
-        - {{ .Values.global.domain }}
-{{ else }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -32,9 +6,10 @@ metadata:
   labels:
     io.kompose.service: {{ .Release.Name }}-ingress
   annotations:
+    {{ if ne .Values.permission "public" }}
     nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?release={{ .Values.release }}"
     nginx.ingress.kubernetes.io/auth-signin: "https://{{ .Values.global.domain }}/accounts/login/?next=$scheme%3A%2F%2F$host"
-    #nginx.ingress.kubernetes.io/auth-response-headers: X-Forwarded-Host
+    {{- end }}
 spec:
   rules:
     - host: {{ .Release.Name }}.{{ .Values.global.domain }}
@@ -51,4 +26,3 @@ spec:
     - secretName: {{ .Values.ingress.secretName }}
       hosts:
         - {{ .Values.global.domain }}
-{{- end }}

--- a/charts/apps/shiny/chart/values.yaml
+++ b/charts/apps/shiny/chart/values.yaml
@@ -20,7 +20,6 @@ imagePullSecrets:
   - name: regcred
 
 ingress:
-  v1beta1: false
   secretName: prod-ingress
 
 podSecurityContext:

--- a/charts/apps/shinyproxy/chart/templates/ingress.yaml
+++ b/charts/apps/shinyproxy/chart/templates/ingress.yaml
@@ -1,29 +1,3 @@
-{{ if .Values.ingress.v1beta1 }}
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: {{ .Release.Name }}-ingress
-  namespace: {{ .Values.namespace }}
-  labels:
-    io.kompose.service: {{ .Release.Name }}-ingress
-  annotations:
-    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?release={{ .Values.release }}"
-    nginx.ingress.kubernetes.io/auth-signin: "https://{{ .Values.global.domain }}/accounts/login/?next=$scheme%3A%2F%2F$host"
-    #nginx.ingress.kubernetes.io/auth-response-headers: X-Forwarded-Host
-spec:
-  rules:
-    - host: {{ .Release.Name }}.{{ .Values.global.domain }}
-      http:
-        paths:
-        - path: /
-          backend:
-            serviceName: {{ .Values.service.name }}
-            servicePort: 80
-  tls:
-    - secretName: prod-ingress
-      hosts:
-        - {{ .Values.global.domain }}
-{{ else }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -32,8 +6,10 @@ metadata:
   labels:
     io.kompose.service: {{ .Release.Name }}-ingress
   annotations:
+    {{ if ne .Values.permission "public" }}
     nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?release={{ .Values.release }}"
     nginx.ingress.kubernetes.io/auth-signin: "https://{{ .Values.global.domain }}/accounts/login/?next=$scheme%3A%2F%2F$host"
+    {{- end }}
     #nginx.ingress.kubernetes.io/auth-response-headers: X-Forwarded-Host
 spec:
   rules:
@@ -51,4 +27,3 @@ spec:
     - secretName: prod-ingress
       hosts:
         - {{ .Values.global.domain }}
-{{- end }}

--- a/charts/apps/shinyproxy/chart/values.yaml
+++ b/charts/apps/shinyproxy/chart/values.yaml
@@ -30,7 +30,6 @@ service:
   name: shinyproxy-svc
 
 ingress:
-  v1beta1: false
   secretName: prod-ingress
 
 s3sync:

--- a/charts/apps/tensorflow-serve/chart/templates/ingress.yaml
+++ b/charts/apps/tensorflow-serve/chart/templates/ingress.yaml
@@ -1,33 +1,3 @@
-{{ if .Values.ingress.v1beta1 }}
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  labels:
-    app: tensorflow-serving
-    host: {{ .Release.Name }}.{{ .Values.global.domain }}
-  annotations:
-    nginx.ingress.kubernetes.io/proxy-connect-timeout: "600"
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
-    nginx.ingress.kubernetes.io/proxy-body-size: "500m"
-    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?release={{ .Values.release }}"
-    nginx.ingress.kubernetes.io/auth-signin: "https://{{ .Values.global.domain }}/accounts/login/?next=$scheme%3A%2F%2F$host"
-  name: {{ .Release.Name }}-ingress
-  namespace: {{ .Values.namespace }}
-spec:
-  rules:
-    - host: {{ .Release.Name }}.{{ .Values.global.domain }}
-      http:
-        paths:
-        - path: /
-          backend:
-            serviceName: {{ $.Release.Name }}-tf-svc
-            servicePort: 80
-  tls:
-    - secretName: prod-ingress
-      hosts:
-        - {{ .Release.Name }}.{{ .Values.global.domain }}
-{{ else }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -39,8 +9,10 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-body-size: "500m"
+    {{ if ne .Values.permission "public" }}
     nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?release={{ .Values.release }}"
     nginx.ingress.kubernetes.io/auth-signin: "https://{{ .Values.global.domain }}/accounts/login/?next=$scheme%3A%2F%2F$host"
+    {{- end }}
   name: {{ .Release.Name }}-ingress
   namespace: {{ .Values.namespace }}
 spec:
@@ -59,5 +31,3 @@ spec:
     - secretName: prod-ingress
       hosts:
         - {{ .Release.Name }}.{{ .Values.global.domain }}
-
-{{- end }}

--- a/charts/apps/tensorflow-serve/chart/values.yaml
+++ b/charts/apps/tensorflow-serve/chart/values.yaml
@@ -44,7 +44,6 @@ imagePullSecrets:
   - name: regcred
 
 ingress:
-  v1beta1: false
 
 podSecurityContext:
   seccompProfile:


### PR DESCRIPTION
## Description

### Bug description:
Creating a public app means that Django makes it public in the UI, but accessing the app without being logged in is blocked by ingress.

### Fix
There are probably a better permanent solution, but me and Hamza thought that this will do for now.
This is how the fix works.
1. Creating or changing app status sets a parameter `{"permission": "public"}`
2. The ingress `yaml` file has an `if` statement, so if permission is public, then we do not require login.

In order to fix this, i have 
1. Added this `if` statement to all apps that can be made public (Shiny, dash, custom app etc)
2. Changed the update-functionality to actually change the app parameters and update the helm installation (thus updating ingress by adding/removing login requirement)

In addition to this, i have removed a bunch of unnecessary `v1beta` statements in ingress. These are never used. 

## Checklist

_If you're unsure about any of the items below, don't hesitate to ask. We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [X] This pull request is against **develop** branch (not applicable for hotfixes)
- [ ] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [ ] I have included, reviewed and executed tests (unit and end2end) to complement my changes
- [ ] I have updated the related documentation (if necessary)
- [ ] I have updated the release notes (releasenotes.md)
- [X] I have added a reviewer for this pull request
- [X] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts
