### PR TITLE
Hotfix/add db reset option

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -115,6 +115,7 @@ services:
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_DB=postgres
       - DEBUG=true
+      - RESET_DB=false
     volumes:
       - .:/app:cached
       - ${PWD}/cluster.conf:/app/cluster.conf

--- a/scripts/run_web.sh
+++ b/scripts/run_web.sh
@@ -7,6 +7,10 @@
 if $INIT; then
     echo "Running studio migrations..."
     
+    if $RESET_DB; then
+        echo "RESETTING DATABASE..."
+        python manage.py reset_db --no-input
+    fi
     
     python manage.py makemigrations
     python manage.py migrate


### PR DESCRIPTION
## Description

In our serve-dev deployment, i believe that we want to have the option to reset the database when we deploy a new version. Therefore, i've added an env variable called `RESET_DB`. If `true`, then the startup script `run_web.sh` will run a reset of the database. 
This is by default set to `false`, so we have to explicitly set it to `true`. My idea is that we override this value in ArgoCD for the dev deployment ONLY. 

I have created a PR in serve-charts, with the same changes being added there. 
 
Is this a good approach? 