### PR TITLE
fixed bug where develop apps settings cant post if user not admin

### DIFF
--- a/apps/views.py
+++ b/apps/views.py
@@ -248,21 +248,21 @@ class AppSettingsView(View):
 
         appinstance.name = request.POST.get("app_name")
         appinstance.description = request.POST.get("app_description")
+        appinstance.parameters.update(parameters)
+        appinstance.access = access
+        appinstance.save()
+        appinstance.app_dependencies.set(app_deps)
+        appinstance.model_dependencies.set(model_deps)
+        
         current_release_name = appinstance.parameters["release"]
         # if subdomain is set as --generated--, then use appname
         if request.POST.get("app_release_name") == "":
             new_release_name = appinstance.parameters["appname"]
         else:
             new_release_name = request.POST.get("app_release_name")
-        appinstance.parameters.update(parameters)
-        appinstance.access = access
-        new_url = appinstance.table_field["url"].replace(current_release_name, new_release_name)
-        appinstance.table_field.update({"url": new_url})
-        appinstance.save()
-        appinstance.app_dependencies.set(app_deps)
-        appinstance.model_dependencies.set(model_deps)
-        # check if new subdomain has been created
-        if current_release_name != new_release_name:
+        if new_release_name and current_release_name != new_release_name:
+            new_url = appinstance.table_field["url"].replace(current_release_name, new_release_name)
+            appinstance.table_field.update({"url": new_url})
             _ = delete_and_deploy_resource.delay(appinstance.pk, new_release_name)
         else:
             # Attempting to deploy apps settings

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -31,6 +31,7 @@ services:
       - DJANGO_SUPERUSER_PASSWORD=dGhpaXNhdmVyeW5vdHNhZmVvbmx
       - DEBUG=true
       - INIT=true
+      - RESET_DB=false
     ports:
       - "8080:8080"
     volumes:
@@ -115,7 +116,6 @@ services:
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_DB=postgres
       - DEBUG=true
-      - RESET_DB=false
     volumes:
       - .:/app:cached
       - ${PWD}/cluster.conf:/app/cluster.conf

--- a/scripts/run_web.sh
+++ b/scripts/run_web.sh
@@ -7,7 +7,7 @@
 if $INIT; then
     echo "Running studio migrations..."
     
-    if $RESET_DB; then
+    if [ -n "${RESET_DB}" ] && [ "${RESET_DB}" = "true" ]; then
         echo "RESETTING DATABASE..."
         python manage.py reset_db --no-input
     fi


### PR DESCRIPTION
## Description

I found a small bug. When deploying a Develop app as a non-superuser, the option to change subdomain is disabled. 
This causes the view logic in `apps/views.py` to try to replace a string with `None`, and it crashes. 
This PR proposes a quick workaround for this. 

I've also:
1. fixed a previous mistake where i put the `RESET_DB` env variable in the wrong container in `docker-compose.yaml`
2. Added a more strict if statement for the database reset.

## Types of changes

What types of changes does your code introduce to Serve?

- [ ] Hotfix (fixing a critical bug in production)
- [X] Bugfix
- [ ] New feature
- [ ] Documentation update

## Checklist

_If you're unsure about any of the items below, don't hesitate to ask. We're here to help! 
This is simply a reminder of what we are going to look for before merging your code._

- [ ] This pull request is against **develop** branch (not applicable for hotfixes)
- [ ] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [ ] I have read the [CONTRIBUTING](https://github.com/scaleoutsystems/stackn/blob/master/CONTRIBUTING.md) doc
- [ ] I have included tests to complement my changes
- [ ] I have updated the related documentation (if necessary) 
- [ ] I have updated the release notes (docs/releasenotes.md)
- [X] I have added a reviewer for this pull request
- [X] I have added myself as an author for this pull request
