### PR TITLE
SS-701 - Public apps should be visible when logged out 

### DIFF
--- a/portal/views.py
+++ b/portal/views.py
@@ -125,7 +125,7 @@ class HomeViewDynamic(View):
         if request.user.is_authenticated:
             return redirect("projects/")
         else:
-            return render(request, self.template, locals())
+            return HomeView.as_view()(request, id=0)
 
 
 def about(request):


### PR DESCRIPTION

Bug description: 
When logged out, public apps and model and news were not visible on the base url (e.g., studio.127.0.0.1.nip.io:8080/), but were visible on `/home`, (e.g., studio.127.0.0.1.nip.io:8080/home).

Bug fix:
Very simple. Instead of returning a rendering of template from `HomeViewDynamic`, i instead return the rendered template from `HomeView`. 

## Checklist

_If you're unsure about any of the items below, don't hesitate to ask. We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [X] This pull request is against **develop** branch (not applicable for hotfixes)
- [ ] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [ ] I have included, reviewed and executed tests (unit and end2end) to complement my changes
- [ ] I have updated the related documentation (if necessary)
- [ ] I have updated the release notes (releasenotes.md)
- [X] I have added a reviewer for this pull request
- [X] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts
