### PR TITLE
SS-721 -  minio is setting persistent volume as none by default

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,7 @@ repos:
   - id: end-of-file-fixer
     exclude: static/vendor/
   - id: pretty-format-json
+    exclude: ^fixtures/
     args: [--autofix]
 
 

--- a/fixtures/projects_templates.json
+++ b/fixtures/projects_templates.json
@@ -64,6 +64,15 @@
       "slug": "default",
       "template": {
         "apps": {
+          "project-minio": {
+            "app:volumeK8s": [
+              "project-vol"
+            ],
+            "credentials.access_key": "accesskey",
+            "credentials.secret_key": "secretkey123",
+            "permission": "project",
+            "slug": "minio"
+          },
           "project-netpolicy": {
             "slug": "netpolicy"
           },
@@ -76,15 +85,6 @@
             "volume.accessModes": "ReadWriteMany",
             "volume.size": "1Gi",
             "volume.storageClass": "microk8s-hostpath"
-          },
-          "project-minio": {
-            "app:volumeK8s": [
-              "project-vol"
-            ],
-            "credentials.access_key": "accesskey",
-            "credentials.secret_key": "secretkey123",
-            "permission": "project",
-            "slug": "minio"
           }
         },
         "environments": {

--- a/fixtures/projects_templates.json
+++ b/fixtures/projects_templates.json
@@ -64,15 +64,6 @@
       "slug": "default",
       "template": {
         "apps": {
-          "project-minio": {
-            "app:volumeK8s": [
-              "project-vol"
-            ],
-            "credentials.access_key": "accesskey",
-            "credentials.secret_key": "secretkey123",
-            "permission": "project",
-            "slug": "minio"
-          },
           "project-netpolicy": {
             "slug": "netpolicy"
           },
@@ -85,6 +76,15 @@
             "volume.accessModes": "ReadWriteMany",
             "volume.size": "1Gi",
             "volume.storageClass": "microk8s-hostpath"
+          },
+          "project-minio": {
+            "app:volumeK8s": [
+              "project-vol"
+            ],
+            "credentials.access_key": "accesskey",
+            "credentials.secret_key": "secretkey123",
+            "permission": "project",
+            "slug": "minio"
           }
         },
         "environments": {


### PR DESCRIPTION
## Description

Bug : minio is setting persistent volume as none by default
Fix: Make sure that the volume is created before minio, so it can mount to it. 

## Checklist

_If you're unsure about any of the items below, don't hesitate to ask. We're here to help! 
This is simply a reminder of what we are going to look for before merging your code._

- [X] This pull request is against **develop** branch (not applicable for hotfixes)
- [ ] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [ ] I have read the [CONTRIBUTING](https://github.com/scaleoutsystems/stackn/blob/master/CONTRIBUTING.md) doc
- [ ] I have included tests to complement my changes
- [ ] I have updated the related documentation (if necessary) 
- [ ] I have updated the release notes (docs/releasenotes.md)
- [X] I have added a reviewer for this pull request
- [X] I have added myself as an author for this pull request

## Further comments

Anything else you think we should know before merging your code!
