### PR TITLE
SS-729 Resolved CORS for OpenApi

### DIFF
--- a/studio/settings.py
+++ b/studio/settings.py
@@ -242,6 +242,10 @@ STATICFILES_DIRS = (os.path.join(BASE_DIR, "static"),)
 # then setting BigAutoField on app level (ex /projects/apps.py)
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
+# Allow all clients to make requests to the OpenAPI
+CORS_URLS_REGEX = r"^/openapi/.*$"
+CORS_ALLOW_ALL_ORIGINS = True
+
 # https://www.django-rest-framework.org/api-guide/authentication/#setting-the-authentication-scheme
 # DEFAULT_VERSIONING_CLASS: NamespaceVersioning uses the URL path scheme, e.g. /v1/
 # https://www.django-rest-framework.org/api-guide/versioning/


### PR DESCRIPTION
This PR adds CORS rules to allow all clients to make requests to the OpenAPI endpoints. I have tested with a js client that a few OpenAPI endpoints are allowed while denying URL:s outside the openapi relative paths.

Jira [link](https://scilifelab.atlassian.net/browse/SS-729)

## Checklist

- [x] This pull request is against **develop** branch (not applicable for hotfixes)
- [x] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [ ] I have included, reviewed and executed tests (unit and end2end) to complement my changes
- [ ] I have updated the related documentation (if necessary)
- [ ] I have updated the release notes (releasenotes.md)
- [x] I have added a reviewer for this pull request
- [x] I have added myself as an author for this pull request
- [x] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts
