### PR TITLE
Hotfix/shiny proxy internet egress

### DIFF
--- a/charts/apps/shinyproxy/chart/templates/configmap.yaml
+++ b/charts/apps/shinyproxy/chart/templates/configmap.yaml
@@ -35,7 +35,7 @@ data:
         id:  {{ .Release.Name }}
         labels:
           sp.instance: {{ .Release.Name }}
-          alow-api-access: "true"
+          allow-internet-egress: "true"
           shinyproxy-app: {{ .Release.Name }}
         kubernetes-pod-patches: |
           - op: add

--- a/charts/apps/shinyproxy/chart/templates/deployment.yaml
+++ b/charts/apps/shinyproxy/chart/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
       affinity:
         {{ .Values.affinity | toYaml | nindent 8 | trim }}
     {{ end }}
-      automountServiceAccountToken: true
+      serviceAccountName: {{ .Values.namespace }}-shinyproxy
       containers:
       - name: serve
         image: {{ .Values.appconfig.proxyimage }}

--- a/charts/apps/shinyproxy/chart/templates/hooks.yaml
+++ b/charts/apps/shinyproxy/chart/templates/hooks.yaml
@@ -17,7 +17,7 @@ spec:
         allow-api-access: "true"
     spec:
       restartPolicy: Never
-      serviceAccountName: default
+      serviceAccountName: {{ .Values.namespace }}-shinyproxy
       containers:
       - name: delete-user-pods
         image: bitnami/kubectl:{{ .Capabilities.KubeVersion.Major }}.{{ .Capabilities.KubeVersion.Minor }}

--- a/charts/apps/shinyproxy/chart/templates/ingress.yaml
+++ b/charts/apps/shinyproxy/chart/templates/ingress.yaml
@@ -10,6 +10,7 @@ metadata:
     nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?release={{ .Values.release }}"
     nginx.ingress.kubernetes.io/auth-signin: "https://{{ .Values.global.domain }}/accounts/login/?next=$scheme%3A%2F%2F$host"
     {{- end }}
+    nginx.ingress.kubernetes.io/proxy-body-size: 2000m
     #nginx.ingress.kubernetes.io/auth-response-headers: X-Forwarded-Host
 spec:
   rules:

--- a/fixtures/objecttype_fixtures.json
+++ b/fixtures/objecttype_fixtures.json
@@ -37,7 +37,7 @@
   },
   {
     "fields": {
-      "app_slug": "fastapi-serve",
+      "app_slug": "python-serve",
       "name": "Python Model Deployment",
       "slug": "python"
     },

--- a/fixtures/projects_templates.json
+++ b/fixtures/projects_templates.json
@@ -31,7 +31,7 @@
             "image": "serve-mlflow:231030-1149",
             "repository": "ghcr.io/scilifelabdatacentre"
           },
-          "Default Serving": {
+          "Python Serving": {
             "app": "python-serve",
             "image": "serve-python:latest",
             "repository": "ghcr.io/scilifelabdatacentre"
@@ -103,7 +103,7 @@
             "image": "serve-mlflow:231030-1149",
             "repository": "ghcr.io/scilifelabdatacentre"
           },
-          "Default Serving": {
+          "Python Serving": {
             "app": "python-serve",
             "image": "serve-python:latest",
             "repository": "ghcr.io/scilifelabdatacentre"


### PR DESCRIPTION
## Description

Fixed issue with Shiny proxy service account and internet access that is required for certain apps such as methylr. Also fixed a small naming issue with the python serve app. Relates to https://scilifelab.atlassian.net/browse/SS-752 and https://scilifelab.atlassian.net/browse/SS-712

## Types of changes

To indicate the type of change (such as bugfix or new feature), use a github pull request label.

## Checklist

_If you're unsure about any of the items below, don't hesitate to ask. We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] This pull request is against **develop** branch (not applicable for hotfixes)
- [x] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [ ] I have included, reviewed and executed tests (unit and end2end) to complement my changes
- [ ] I have updated the related documentation (if necessary)
- [ ] I have updated the release notes (releasenotes.md)
- [x] I have added a reviewer for this pull request
- [x] I have added myself as an author for this pull request
- [x] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts

## Further comments

Anything else you think we should know before merging your code!
