### PR TITLE
Fixed bug where minio crashed when bucket existed

### DIFF
--- a/charts/apps/minio/chart/templates/deployment.yaml
+++ b/charts/apps/minio/chart/templates/deployment.yaml
@@ -82,7 +82,7 @@ spec:
                 sleep 5
                 mc alias set local http://127.0.0.1:9000 ${MINIO_ROOT_USER} ${MINIO_ROOT_PASSWORD}
                 mc admin user add local {{ .Values.credentials.access_key }} {{ .Values.credentials.secret_key }}
-                mc mb local/data-bucket
+                mc mb local/data-bucket || true
                 mc admin policy attach local readwrite --user {{ .Values.credentials.access_key }} || true
       hostname: {{ .Release.Name }}-minio
       restartPolicy: Always


### PR DESCRIPTION
## Description

Minio didn't run its `postStartHook` properly. It failed on the create bucket step if the bucket already exists. 
I've added `|| true` catch this. 
The logic is like this: Either it creates it and returns success, or it has already been created, so it's fine anyways. 

Tried this on 5 running minio instances and it worked. 

## Checklist

_If you're unsure about any of the items below, don't hesitate to ask. We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [X] This pull request is against **develop** branch (not applicable for hotfixes)
- [ ] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [ ] I have included, reviewed and executed tests (unit and end2end) to complement my changes
- [ ] I have updated the related documentation (if necessary)
- [ ] I have updated the release notes (releasenotes.md)
- [X] I have added a reviewer for this pull request
- [X] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts
