### PR TITLE
SS-907 Fixed update of long app status texts

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -854,7 +854,12 @@ def update_app_status(request):
 
             # Required input
             release = request.data["release"]
+
             new_status = request.data["new-status"]
+
+            if len(new_status) > 15:
+                print(f"DEBUG: Status code is longer than 15 chars so shortening: {new_status}")
+                new_status = new_status[:15]
 
             event_ts = datetime.strptime(request.data["event-ts"], "%Y-%m-%dT%H:%M:%S.%fZ")
             event_ts = utc.localize(event_ts)

--- a/apps/helpers.py
+++ b/apps/helpers.py
@@ -235,17 +235,21 @@ def handle_update_status_request(
     request should be performed or ignored.
 
     :param release str: The release id of the app instance, stored in the AppInstance.parameters dict.
-    :param new_status str: The new status code.
+    :param new_status str: The new status code. Trimmed to max 15 chars if needed.
     :param event_ts timestamp: A JSON-formatted timestamp in UTC, e.g. 2024-01-25T16:02:50.00Z.
     :param event_msg json dict: An optional json dict containing pod-msg and/or container-msg.
     :returns: A value from the HandleUpdateStatusResponseCode enum.
               Raises an ObjectDoesNotExist exception if the app instance does not exist.
     """
 
+    if len(new_status) > 15:
+        new_status = new_status[:15]
+
     try:
         # Begin by verifying that the requested app instance exists
         # We wrap the select and update tasks in a select_for_update lock
         # to avoid race conditions.
+
         with transaction.atomic():
             app_instance = (
                 AppInstance.objects.select_for_update().filter(parameters__contains={"release": release}).last()


### PR DESCRIPTION
## Description

Fixed updating of the app status when the status code text is longer than 15 chars. 

Jira [link](https://scilifelab.atlassian.net/browse/SS-907)

## Checklist

- [x] This pull request is against **develop** branch (not applicable for hotfixes)
- [x] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [x] I have included, reviewed and executed tests (unit and end2end) to complement my changes
- [ ] I have updated the related documentation (if necessary)
- [ ] I have updated the release notes (releasenotes.md)
- [x] I have added a reviewer for this pull request
- [x] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts
