### PR TITLE
Bugfix/admin action reset applimits

### DIFF
--- a/apps/helpers.py
+++ b/apps/helpers.py
@@ -192,6 +192,9 @@ def create_app_instance(user, project, app, app_settings, data=[], wait=False):
     status.info = app_instance.parameters["release"]
     if "appconfig" in app_instance.parameters:
         if "path" in app_instance.parameters["appconfig"]:
+            # remove trailing / in all cases
+            if app_instance.parameters["appconfig"]["path"] != "/":
+                app_instance.parameters["appconfig"]["path"] = app_instance.parameters["appconfig"]["path"].rstrip("/")
             if app_deps:
                 if not created_by_admin:
                     app_instance.parameters["appconfig"]["path"] = (

--- a/apps/views.py
+++ b/apps/views.py
@@ -255,7 +255,6 @@ class AppSettingsView(View):
 
         app = appinstance.app
         app_settings = app.settings
-        print("SETTINGSSS: ", appinstance.parameters["appconfig"])
         body = request.POST.copy()
 
         if not app.user_can_edit:
@@ -307,6 +306,9 @@ class AppSettingsView(View):
         appinstance.app_dependencies.set(app_deps)
         appinstance.model_dependencies.set(model_deps)
         if "appconfig" in appinstance.parameters and appinstance.app.slug == "customapp":
+            # remove trailing / in all cases
+            if appinstance.parameters["appconfig"]["path"] != "/":
+                appinstance.parameters["appconfig"]["path"] = appinstance.parameters["appconfig"]["path"].rstrip("/")
             appinstance.parameters["created_by_admin"] = created_by_admin
             # if app is created by admin but admin user is not updating it dont change path.
             if created_by_admin:

--- a/apps/views.py
+++ b/apps/views.py
@@ -77,10 +77,10 @@ class GetLogsView(View):
             try:
                 url = settings.LOKI_SVC + "/loki/api/v1/query_range"
                 app_params = app.parameters
-                if app.app.slug == "customapp":
-                    log_query = '{release="' + app_params["release"] + '",container="' + container + '"}'
+                if app.app.slug == "shinyproxyapp":
+                    log_query = '{release="' + app_params["release"] + '",container="' + "serve" + '"}'
                 else:
-                    log_query = '{release="' + app_params["release"] + '"}'
+                    log_query = '{release="' + app_params["release"] + '",container="' + container + '"}'
                 print(log_query)
                 query = {
                     "query": log_query,

--- a/charts/apps/custom-app/chart/templates/deployment.yaml
+++ b/charts/apps/custom-app/chart/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
         command:
           - /bin/sh
           - -c
-          - cp -r -n {{ $.Values.appconfig.path }}/* /tmp
+          - if [ -n "$(ls -A {{ $.Values.appconfig.path }})" ]; then echo "Copying data..." && cp -r -n {{ $.Values.appconfig.path }}/* /tmp && echo "Done Copying"; elif [ -d "{{ $.Values.appconfig.path }}" ]; then echo "Empty directory. Nothing to copy."; else echo "Directory does not exist" && cp -r -n {{ $.Values.appconfig.path }}/* /tmp;  fi
         volumeMounts:
         {{- range $key, $value := .Values.apps.volumeK8s }}
         - name: {{ $key }}

--- a/charts/apps/custom-app/chart/templates/deployment.yaml
+++ b/charts/apps/custom-app/chart/templates/deployment.yaml
@@ -48,7 +48,14 @@ spec:
         command:
           - /bin/sh
           - -c
-          - if [ -n "$(ls -A {{ $.Values.appconfig.path }})" ]; then echo "Copying data..." && cp -r -n {{ $.Values.appconfig.path }}/* /tmp && echo "Done Copying"; elif [ -d "{{ $.Values.appconfig.path }}" ]; then echo "Empty directory. Nothing to copy."; else echo "Directory does not exist" && cp -r -n {{ $.Values.appconfig.path }}/* /tmp;  fi
+          - |
+            if [ -n "$(ls -A {{ $.Values.appconfig.path }})" ]; then
+              echo "Copying data..." && cp -r -n {{ $.Values.appconfig.path }}/* /tmp && echo "Done Copying";
+            elif [ -d "{{ $.Values.appconfig.path }}" ]; then
+              echo "Empty directory. Nothing to copy.";
+            else
+              echo "Directory does not exist" && cp -r -n {{ $.Values.appconfig.path }}/* /tmp;
+            fi
         volumeMounts:
         {{- range $key, $value := .Values.apps.volumeK8s }}
         - name: {{ $key }}

--- a/projects/admin.py
+++ b/projects/admin.py
@@ -1,5 +1,5 @@
-from django.contrib import admin
 from django.conf import settings
+from django.contrib import admin
 
 from .models import (
     S3,

--- a/projects/admin.py
+++ b/projects/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.conf import settings
 
 from .models import (
     S3,
@@ -27,6 +28,11 @@ admin.site.register(ReleaseName)
 class ProjectAdmin(admin.ModelAdmin):
     list_display = ("name", "owner", "status", "updated_at")
     list_filter = ["owner", "status"]
+    actions = ["update_app_limits"]
+
+    @admin.action(description="Reset app limits")
+    def update_app_limits(self, request, queryset):
+        queryset.update(apps_per_project=settings.APPS_PER_PROJECT_LIMIT)
 
 
 @admin.register(Flavor)


### PR DESCRIPTION
Added an admin action to be able to reset app limits to default values in projects. This needs to be run from within the admin panel. Fixed small issue with paths (trailing slash needed to be removed) and configured copy commands in custom apps chart to handle empty directory. Also fixed issue [SS-912](https://scilifelab.atlassian.net/browse/SS-912).

- [x] This pull request is against **develop** branch (not applicable for hotfixes)
- [x] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [ ] I have included, reviewed and executed tests (unit and end2end) to complement my changes
- [ ] I have updated the related documentation (if necessary)
- [ ] I have updated the release notes (releasenotes.md)
- [x] I have added a reviewer for this pull request
- [x] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts

## Further comments

Anything else you think we should know before merging your code!
