### PR TITLE
Hotfix/timestamp mismatch for logs

### DIFF
--- a/apps/views.py
+++ b/apps/views.py
@@ -90,7 +90,7 @@ class GetLogsView(View):
                 res = requests.get(url, params=query)
                 res_json = res.json()["data"]["result"]
                 # TODO: change timestamp logic. Timestamps are different in prod and dev
-                if settings.DEBUG == True:
+                if settings.DEBUG is True:
                     prod_timestamp = False
                 else:
                     prod_timestamp = True

--- a/apps/views.py
+++ b/apps/views.py
@@ -89,13 +89,20 @@ class GetLogsView(View):
                 }
                 res = requests.get(url, params=query)
                 res_json = res.json()["data"]["result"]
-
+                #TODO: change timestamp logic. Timestamps are different in prod and dev
+                if settings.DEBUG == True:
+                    prod_timestamp = False
+                else:
+                    prod_timestamp = True
                 for item in res_json:
                     for log_line in reversed(item["values"]):
                         # separate timestamp and log
                         separated_log = log_line[1].split(None, 1)
                         # improve timestamp formatting for table
-                        formatted_time = datetime.strptime(separated_log[0][:-10], "%Y-%m-%dT%H:%M:%S.%f")
+                        if prod_timestamp:
+                            formatted_time = datetime.strptime(separated_log[0][:-10], "%Y-%m-%dT%H:%M:%S.%f")
+                        else:
+                            formatted_time = datetime.strptime(separated_log[0][:-4], "%Y-%m-%dT%H:%M:%S.%f")
                         separated_log[0] = datetime.strftime(formatted_time, "%Y-%m-%d, %H:%M:%S")
                         logs.append(separated_log)
 

--- a/apps/views.py
+++ b/apps/views.py
@@ -89,7 +89,7 @@ class GetLogsView(View):
                 }
                 res = requests.get(url, params=query)
                 res_json = res.json()["data"]["result"]
-                #TODO: change timestamp logic. Timestamps are different in prod and dev
+                # TODO: change timestamp logic. Timestamps are different in prod and dev
                 if settings.DEBUG == True:
                     prod_timestamp = False
                 else:

--- a/apps/views.py
+++ b/apps/views.py
@@ -95,7 +95,7 @@ class GetLogsView(View):
                         # separate timestamp and log
                         separated_log = log_line[1].split(None, 1)
                         # improve timestamp formatting for table
-                        formatted_time = datetime.strptime(separated_log[0][:-4], "%Y-%m-%dT%H:%M:%S.%f")
+                        formatted_time = datetime.strptime(separated_log[0][:-10], "%Y-%m-%dT%H:%M:%S.%f")
                         separated_log[0] = datetime.strftime(formatted_time, "%Y-%m-%d, %H:%M:%S")
                         logs.append(separated_log)
 


### PR DESCRIPTION
Hotfix for logs not working in production environment. Dev cluster timestamps from containers are of the format 2024-02-08T11:36:10.49903621Z and from prod the format is "2024-02-08T15:22:46.160554532+01:00". Patched it to handle this now using DEBUG option from settings. Needs to be addressed in a later release to use different timestamps options from Loki. Jira link [SS-926](https://scilifelab.atlassian.net/browse/SS-926).
## Checklist

_If you're unsure about any of the items below, don't hesitate to ask. We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [ ] This pull request is against **develop** branch (not applicable for hotfixes)
- [ ] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [ ] I have included, reviewed and executed tests (unit and end2end) to complement my changes
- [ ] I have updated the related documentation (if necessary)
- [ ] I have updated the release notes (releasenotes.md)
- [ ] I have added a reviewer for this pull request
- [ ] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts
