### PR TITLE
SS-841 Polishing app type tissuumaps

### DIFF
--- a/charts/apps/tissuumaps/chart/values.yaml
+++ b/charts/apps/tissuumaps/chart/values.yaml
@@ -12,7 +12,7 @@ apps:
 
 appconfig:
   #port: 80 Instead uses the port and target port defined in the fixture
-  image: docker.io/cavenel/tissuumaps:3.2.0.4 # ghcr.io/tissuumaps/tissuumaps:3
+  image: docker.io/cavenel/tissuumaps:3
   path: /mnt/data/
 
 service:

--- a/fixtures/apps_fixtures.json
+++ b/fixtures/apps_fixtures.json
@@ -831,7 +831,7 @@
       "category": "serve",
       "chart": "apps/tissuumaps/chart",
       "created_on": "2023-08-25T21:34:37.815Z",
-      "description": "Apps built with the TissUUmaps image.",
+      "description": "App to visualise and explore data using TissUUmaps.",
       "logo": "tissuumaps-logo.svg",
       "name": "TissUUmaps App",
       "priority": "400",
@@ -850,14 +850,14 @@
         "permissions": {
           "private": {
             "option": "true",
-            "value": "false"
+            "value": "true"
           },
           "project": {
             "option": "true",
-            "value": "true"
+            "value": "false"
           },
           "public": {
-            "option": "false",
+            "option": "true",
             "value": "false"
           }
         },

--- a/studio/settings.py
+++ b/studio/settings.py
@@ -365,6 +365,7 @@ APPS_PER_PROJECT_LIMIT = {
     "vscode": 3,
     "jupyter-lab": 3,
     "mlflow": 1,
+    "tissuumaps": 1,
     "volumeK8s": 0,
     "minio": 1,
     "mongo-express": 0,

--- a/templates/apps/create.html
+++ b/templates/apps/create.html
@@ -22,6 +22,8 @@
         <p>This form allows you to start hosting a Dash app at SciLifeLab Serve. Please read our <a href="/docs/application-hosting/dash/">documentation page on Dash apps</a> for step-by-step instructions.</p>
         {% elif app.slug in 'shinyapp,shinyproxyapp' %}
         <p>This form allows you to start hosting a Shiny app at SciLifeLab Serve. Please read our <a href="/docs/application-hosting/shiny/">documentation page on Shiny apps</a> for step-by-step instructions.</p>
+        {% elif app.slug == 'tissuumaps' %}
+        <p>This form allows you to start hosting your own TissUUmaps instance at SciLifeLab Serve. After your app has been created you will need to upload the data to your project. We suggest that you create the app with Permissions initially set to private, upload the data, and then edit the app settings to change the Permissions to public. Please read our <a href="/docs/application-hosting/tissuumaps/" target="_blank">documentation page on TissUUmaps apps</a> for step-by-step instructions.</p>
         {% endif %}
         {% if app.slug in 'jupyter-lab,rstudio,vscode' %}
         <p>Note that <b>after 7 days the created {{ app.name }} instance will be deleted</b>, only the files saved in 'project-vol' will stay available.</p>


### PR DESCRIPTION
## Description

This PR completes the new app type TissUUmaps by improving the user information texts in the UI. It also sets the max number of TissUUmaps app instances per project to 1. There is an associated change to the settings.py configmap in the serve-charts repo.

## Checklist

- [x] This pull request is against **develop** branch (not applicable for hotfixes)
- [x] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [x] I have included, reviewed and executed tests (unit and end2end) to complement my changes
- [ ] I have updated the related documentation (if necessary)
- [x] I have added a reviewer for this pull request
- [x] I have added myself as an author for this pull request
- [x] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts
