### PR TITLE
Add requirement for unique docker image tags for each version of depoyed apps

### DIFF
--- a/charts/apps/custom-app/chart/templates/deployment.yaml
+++ b/charts/apps/custom-app/chart/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
       initContainers:
       - name: copy-to-pvc
         image: {{ .Values.appconfig.image }}
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         command:
           - /bin/sh
           - -c
@@ -65,7 +65,7 @@ spec:
       containers:
       - name: {{ .Values.appname }}
         image: {{ .Values.appconfig.image }}
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         command:
           - /bin/sh
           - -c

--- a/charts/apps/dash/chart/templates/deployment.yaml
+++ b/charts/apps/dash/chart/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
       containers:
       - name: {{ .Values.appname }}
         image: {{ .Values.appconfig.image }}
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         ports:
           - containerPort: {{ .Values.appconfig.port }}
         securityContext:

--- a/charts/apps/python-serve/chart/templates/deployment.yaml
+++ b/charts/apps/python-serve/chart/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
       containers:
       - name: reverse-proxy
         image: nginx:alpine
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: rp-conf
           mountPath: /etc/nginx
@@ -79,7 +79,7 @@ spec:
         - name: STACKN_MODEL_PATH
           value: "/home/user/models"
         image: {{ .Values.environment.repository }}/{{ .Values.environment.image }}
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: {{ .Values.appconfig.port }}
       terminationGracePeriodSeconds: 30

--- a/charts/apps/shiny/chart/templates/deployment.yaml
+++ b/charts/apps/shiny/chart/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
       containers:
       - name: {{ .Values.appname }}
         image: {{ .Values.appconfig.image }}
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
         resources:

--- a/charts/apps/shinyproxy/chart/templates/configmap.yaml
+++ b/charts/apps/shinyproxy/chart/templates/configmap.yaml
@@ -19,7 +19,7 @@ data:
       kubernetes:
         internal-networking: true
         namespace: {{ .Values.namespace }}
-        image-pull-policy: Always
+        image-pull-policy: IfNotPresent
       hide-navbar: true
       landing-page: /app/{{ .Release.Name }}
       livenessProbe: {}

--- a/charts/apps/tissuumaps/chart/templates/deployment.yaml
+++ b/charts/apps/tissuumaps/chart/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
       containers:
       - name: {{ .Values.appname }}
         image: {{ .Values.appconfig.image }}
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         ports:
           - containerPort: {{ .Values.service.targetport }}
         securityContext:

--- a/templates/apps/create.html
+++ b/templates/apps/create.html
@@ -225,7 +225,7 @@
                         {% if subval.type == "string" %}
                         <label class="form-label">{{ subval.title }}</label>
                         {% if subkey == "image" %}
-                        <span class="bi bi-question-circle" style="color: #989da0" data-bs-toggle="tooltip" title="" data-bs-placement="right" data-bs-original-title="DockerHub or Github Docker Image for the app">
+                        <span class="bi bi-question-circle" style="color: #989da0" data-bs-toggle="tooltip" title="" data-bs-placement="right" data-bs-original-title="Docker Image for the app uploaded to DockerHub or GitHub. Each version of your app should have a unique tag.">
                         </span>
                         <input type="text" id="{{ subkey }}" name="{{ key }}.{{ subkey }}" value="" placeholder="{{ subval.default }}" class="form-control" required>
                         <div class="invalid-feedback">

--- a/templates/apps/update.html
+++ b/templates/apps/update.html
@@ -230,7 +230,7 @@
                         {% if subval.type == "string" %}
                         <label class="form-label">{{ subval.title }}</label>
                         {% if subkey == "image" %}
-                        <span class="bi bi-question-circle" style="color: #989da0" data-bs-toggle="tooltip" title="" data-bs-placement="right" data-bs-original-title="DockerHub or Github Docker Image for the app">
+                        <span class="bi bi-question-circle" style="color: #989da0" data-bs-toggle="tooltip" title="" data-bs-placement="right" data-bs-original-title="Docker Image for the app uploaded to DockerHub or GitHub. The image needs to be publicly available. Each version of your app should have a unique tag.">
                         </span>
                         <input type="text" id="{{ subkey }}" name="{{ key }}.{{ subkey }}" value="{{ subval.default }}" class="form-control" required>
                         <div class="invalid-feedback">


### PR DESCRIPTION
## Description

In this PR I set the ImagePullPolicy to IfNotPresent so that the cluster does not retrieve new versions of the images that users supply unless the new version has a unique tag. It solves the issue [SS-927](https://scilifelab.atlassian.net/browse/SS-927).

## Checklist

_If you're unsure about any of the items below, don't hesitate to ask. We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] This pull request is against **develop** branch (not applicable for hotfixes)
- [x] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [ ] I have included, reviewed and executed tests (unit and end2end) to complement my changes
- [ ] I have updated the related documentation (if necessary)
- [ ] I have added a reviewer for this pull request
- [x] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts