### PR TITLE
SS 841 Adjust the TissUUmaps pull policy and configuration

### DIFF
--- a/charts/apps/tissuumaps/chart/templates/deployment.yaml
+++ b/charts/apps/tissuumaps/chart/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
       containers:
       - name: {{ .Values.appname }}
         image: {{ .Values.appconfig.image }}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         ports:
           - containerPort: {{ .Values.service.targetport }}
         securityContext:

--- a/charts/apps/tissuumaps/chart/templates/tissuumaps-configmap.yaml
+++ b/charts/apps/tissuumaps/chart/templates/tissuumaps-configmap.yaml
@@ -9,3 +9,5 @@ data:
     PLUGIN_FOLDER = "/mnt/data/plugins/"
     SLIDE_DIR = "/mnt/data/shared/"
     DEFAULT_PROJECT = "project.tmap"
+    COLLAPSE_TOP_MENU = True
+    PROJECT_LIST = True


### PR DESCRIPTION
## Description

This PR makes 2 adjustments to the TissUUmaps app type. The image pull policy is set to Always and two additional settings are added to the configuration file to support version 3.2.0.5. 

## Checklist

- [x] This pull request is against **develop** branch (not applicable for hotfixes)
- [ ] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [ ] I have included, reviewed and executed tests (unit and end2end) to complement my changes
- [ ] I have updated the related documentation (if necessary)
- [x] I have added a reviewer for this pull request
- [x] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts
