### PR TITLE
update workflow to reduced image on push tag

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -93,6 +93,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          build-args: DISABLE_EXTRAS=${{ github.event_name == 'push' && contains(github.ref, 'refs/tags/') }}
           push: "${{ github.event_name != 'pull_request' }}"
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Description

Introducing logic to create a reduced image when tag is created. 

### How does it work?
I have added this to the build part of the publish workflow
```build-args: DISABLE_EXTRAS=${{ github.event_name == 'push' && contains(github.ref, 'refs/tags/') }}```
and this will only evaluate to `true` then we push a tag. And in general, this tag needs to start with `v`. 

I have tried to create a dummy-tag and it seems to work. Now we need to test this image on the cluster. 