### PR TITLE
SS 950 apps fail if names contains comma

### DIFF
--- a/apps/serialize.py
+++ b/apps/serialize.py
@@ -15,8 +15,7 @@ from .models import AppInstance, Apps
 
 User = get_user_model()
 
-# TODO: minor-refactor: make upper case
-key_words = [
+KEYWORDS = [
     "appobj",
     "model",
     "flavor",
@@ -181,17 +180,26 @@ def serialize_apps(form_selection, project):
 
 
 def serialize_primitives(form_selection):
+    """
+    This function serializes all values that are not part of the KEYWORDS list at the top.
+    """
     print("SERIALIZING PRIMITIVES")
     parameters = dict()
     # TODO: minor-refactor: do for loop over form_selection without new variable
     keys = form_selection.keys()
     for key in keys:
-        if key not in key_words and "app:" not in key:
+        if key not in KEYWORDS and "app:" not in key:
             parameters[key] = form_selection[key].replace("\r\n", "\n")
+
+            # Turn string booleans to python booleans
             if parameters[key] == "False":
                 parameters[key] = False
             elif parameters[key] == "True":
                 parameters[key] = True
+
+            # Slugify app_name so that users can use special chars in their app names.
+            elif key == "app_name":
+                parameters[key] = slugify(parameters[key])
     print(parameters)
     return flatten_json.unflatten(parameters, ".")
 


### PR DESCRIPTION
## Description
[SS-950](https://scilifelab.atlassian.net/browse/SS-950?atlOrigin=eyJpIjoiMGNmZjMyMmYyMDJhNDE3YmFiNzg1YjA2ZTgzMzIyNDAiLCJwIjoiaiJ9)
It turns out that the solution for this was simple and quite elegant, but it took some time to figure out. See the flow chart.

Issue: Users could not create apps with comma or any other chars
Reason: We save the helm charts using `app_name`, and a helm chart can only use numbers, alphabet and `-`. 
Solution: Slugify `app_name` when it is set in the parameters dict.

![flow](https://github.com/ScilifelabDataCentre/stackn/assets/78532175/95d29c26-bb1d-4644-bc1b-56d1c828cadb)

## Checklist

_If you're unsure about any of the items below, don't hesitate to ask. We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] This pull request is against **develop** branch (not applicable for hotfixes)
- [ ] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [x] I have included, reviewed and executed tests (unit and end2end) to complement my changes
- [ ] I have updated the related documentation (if necessary)
- [x] I have added a reviewer for this pull request
- [x] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts

