### PR TITLE
update chart with ingress link only logic

### DIFF
--- a/charts/apps/tissuumaps/chart/templates/ingress.yaml
+++ b/charts/apps/tissuumaps/chart/templates/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     io.kompose.service: {{ .Release.Name }}-ingress
   annotations:
-    {{ if ne .Values.permission "public" }}
+    {{ if and (ne .Values.permission "public") (ne .Values.permission "link") }}
     nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?release={{ .Values.release }}"
     nginx.ingress.kubernetes.io/auth-signin: "https://{{ .Values.global.domain }}/accounts/login/?next=$scheme%3A%2F%2F$host"
     {{- end }}


### PR DESCRIPTION
## Description

Fixing missed auth url header for link only apps in tissuumaps. 