### PR TITLE
SS 871 Authentication token expiry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN apk add --update --no-cache \
     curl
 
 # Install Poetry, change configs and install packages.
-RUN curl -sSL https://install.python-poetry.org | POETRY_VERSION=1.7.1 python3 - \
+RUN curl -sSL https://install.python-poetry.org | POETRY_VERSION=1.8.0 python3 - \
     && /root/.local/bin/poetry self add poetry-plugin-export \
     && /root/.local/bin/poetry config virtualenvs.create false \
     && /root/.local/bin/poetry config installer.max-workers 10 \

--- a/api/APIpermissions.py
+++ b/api/APIpermissions.py
@@ -18,7 +18,7 @@ class IsTokenAuthenticated(BasePermission):
 
         # Set the expiration duration in seconds for the authentication tokens
         # TODO: move to settings file
-        AUTH_TOKEN_EXPIRATION = 60 * 2
+        AUTH_TOKEN_EXPIRATION = 60 * 20
 
         # If the existing token is older than AUTH_TOKEN_EXPIRATION, then recreate the object
         token_expiry = request.auth.created + timedelta(seconds=AUTH_TOKEN_EXPIRATION)

--- a/api/APIpermissions.py
+++ b/api/APIpermissions.py
@@ -17,8 +17,9 @@ class IsTokenAuthenticated(BasePermission):
         Returns a boolean value that DRF will convert to an exception.
         """
 
-        # If the existing token is older than AUTH_TOKEN_EXPIRATION, then recreate the object
-        # Give a small 10 second grace duration to give the CustomAuthToken class a change to renew the token
+        # If the user token is older than AUTH_TOKEN_EXPIRATION, then consider it expired
+        # Give a small 10 second grace duration to give the CustomAuthToken class a chance to renew the token
+        # The request.auth.created field contains a datetime value
         token_expiry = request.auth.created + timedelta(seconds=settings.AUTH_TOKEN_EXPIRATION + 10)
 
         print(f"DEBUG - Token expires = {token_expiry}, has expired = {datetime.now(timezone.utc) < token_expiry}")

--- a/api/views.py
+++ b/api/views.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import time
 from datetime import datetime, timedelta, timezone
 
@@ -63,8 +62,6 @@ from .serializers import (
     UserSerializer,
 )
 
-logger = logging.getLogger(__name__)
-
 
 # A customized version of the obtain_auth_token view
 # It will either create or fetch the user token
@@ -78,9 +75,10 @@ class CustomAuthToken(ObtainAuthToken):
         token, created = Token.objects.get_or_create(user=user)
 
         # If the existing token is older than AUTH_TOKEN_EXPIRATION, then recreate the object
+        # The token.created field contains a datetime value
         token_expiry = token.created + timedelta(seconds=settings.AUTH_TOKEN_EXPIRATION)
 
-        if datetime.now(timezone.utc) > token_expiry:
+        if not created and datetime.now(timezone.utc) > token_expiry:
             print(f"INFO - Token expired as of {token_expiry}. Now generating a new token.")
             token.delete()
             token, created = Token.objects.get_or_create(user=user)

--- a/api/views.py
+++ b/api/views.py
@@ -703,6 +703,7 @@ class AppList(
     ListModelMixin,
 ):
     permission_classes = (
+        IsTokenAuthenticated,
         IsAuthenticated,
         AdminPermission,
     )
@@ -792,6 +793,7 @@ class ProjectTemplateList(
     ListModelMixin,
 ):
     permission_classes = (
+        IsTokenAuthenticated,
         IsAuthenticated,
         AdminPermission,
     )

--- a/api/views.py
+++ b/api/views.py
@@ -77,18 +77,14 @@ class CustomAuthToken(ObtainAuthToken):
 
         token, created = Token.objects.get_or_create(user=user)
 
-        # Set the expiration duration in seconds for the authentication tokens
-        # TODO: move to settings file
-        AUTH_TOKEN_EXPIRATION = 60 * 20
-
         # If the existing token is older than AUTH_TOKEN_EXPIRATION, then recreate the object
-        token_expiry = token.created + timedelta(seconds=AUTH_TOKEN_EXPIRATION)
+        token_expiry = token.created + timedelta(seconds=settings.AUTH_TOKEN_EXPIRATION)
 
         if datetime.now(timezone.utc) > token_expiry:
-            print(f"Token expired as of {token_expiry}. Now generating a new token.   ")
+            print(f"INFO - Token expired as of {token_expiry}. Now generating a new token.")
             token.delete()
             token, created = Token.objects.get_or_create(user=user)
-            token_expiry = token.created + timedelta(seconds=AUTH_TOKEN_EXPIRATION)
+            token_expiry = token.created + timedelta(seconds=settings.AUTH_TOKEN_EXPIRATION)
 
         return Response({"token": token.key, "user_id": user.pk, "email": user.email, "expires": token_expiry})
 

--- a/api/views.py
+++ b/api/views.py
@@ -79,7 +79,7 @@ class CustomAuthToken(ObtainAuthToken):
 
         # Set the expiration duration in seconds for the authentication tokens
         # TODO: move to settings file
-        AUTH_TOKEN_EXPIRATION = 60 * 2
+        AUTH_TOKEN_EXPIRATION = 60 * 20
 
         # If the existing token is older than AUTH_TOKEN_EXPIRATION, then recreate the object
         token_expiry = token.created + timedelta(seconds=AUTH_TOKEN_EXPIRATION)

--- a/portal/views.py
+++ b/portal/views.py
@@ -80,7 +80,6 @@ def get_public_apps(request, id=0, get_all=True):
     elif "tag_count" not in request.GET:
         tag = ""
         request.session["app_tag_filters"] = []
-    print("app_tag_filters: ", request.session["app_tag_filters"])
 
     # changed list of published model only if tag filters are present
     if request.session["app_tag_filters"]:

--- a/studio/settings.py
+++ b/studio/settings.py
@@ -323,7 +323,7 @@ STORAGECLASS = "microk8s-hostpath"
 # This can be simply "localhost", but it's better to test with a
 # wildcard dns such as nip.io
 DOMAIN = "studio.127.0.0.1.nip.io"
-AUTH_DOMAIN = "192.168.0.107"
+AUTH_DOMAIN = "10.0.144.239"
 AUTH_PROTOCOL = "http"
 STUDIO_URL = "http://studio.127.0.0.1.nip.io:8080"
 # To enable sticky sessions for k8s ingress

--- a/studio/settings.py
+++ b/studio/settings.py
@@ -191,6 +191,9 @@ SESSION_SAVE_EVERY_REQUEST = True
 # Whether to expire the session when the user closes their browser:
 SESSION_EXPIRE_AT_BROWSER_CLOSE = False
 
+# The expiration duration in seconds for authentication tokens
+AUTH_TOKEN_EXPIRATION = 60 * 10
+
 # Settings for the Django Axes brute force login protection
 # Number of allowed login failures before action is taken
 AXES_FAILURE_LIMIT = 5
@@ -320,7 +323,7 @@ STORAGECLASS = "microk8s-hostpath"
 # This can be simply "localhost", but it's better to test with a
 # wildcard dns such as nip.io
 DOMAIN = "studio.127.0.0.1.nip.io"
-AUTH_DOMAIN = "10.0.144.239"
+AUTH_DOMAIN = "192.168.0.107"
 AUTH_PROTOCOL = "http"
 STUDIO_URL = "http://studio.127.0.0.1.nip.io:8080"
 # To enable sticky sessions for k8s ingress

--- a/studio/settings.py
+++ b/studio/settings.py
@@ -192,7 +192,7 @@ SESSION_SAVE_EVERY_REQUEST = True
 SESSION_EXPIRE_AT_BROWSER_CLOSE = False
 
 # The expiration duration in seconds for authentication tokens
-AUTH_TOKEN_EXPIRATION = 60 * 10
+AUTH_TOKEN_EXPIRATION = 60 * 20
 
 # Settings for the Django Axes brute force login protection
 # Number of allowed login failures before action is taken


### PR DESCRIPTION
## Description

This PR adds the ability to add expiration to API authentication tokens. To use add the permission class IsTokenAuthenticated to the function decorator. There is one configuration setting to set the expiration duration called AUTH_TOKEN_EXPIRATION

Jira [link](https://scilifelab.atlassian.net/browse/SS-871)

## Checklist

- [x] This pull request is against **develop** branch (not applicable for hotfixes)
- [x] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [x] I have included, reviewed and executed tests (unit and end2end) to complement my changes
- [ ] I have updated the related documentation (if necessary)
- [x] I have added a reviewer for this pull request
- [x] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts
