### PR TITLE
fix-missing-link-only-option-in-old-apps

### DIFF
--- a/apps/generate_form.py
+++ b/apps/generate_form.py
@@ -160,10 +160,10 @@ def get_form_permission(aset, project, appinstance=[]):
             try:
                 ai_vals = appinstance.parameters
                 logger.info(ai_vals["permissions"])
-                form_permissions["public"]["value"] = ai_vals["permissions"]["public"]
-                form_permissions["project"]["value"] = ai_vals["permissions"]["project"]
-                form_permissions["private"]["value"] = ai_vals["permissions"]["private"]
-                form_permissions["link"]["value"] = ai_vals["permissions"]["link"]
+                form_permissions["public"]["value"] = ai_vals["permissions"].get("public", False)
+                form_permissions["project"]["value"] = ai_vals["permissions"].get("project", False)
+                form_permissions["private"]["value"] = ai_vals["permissions"].get("private", False)
+                form_permissions["link"]["value"] = ai_vals["permissions"].get("link", False)
                 logger.info(form_permissions)
             except Exception:
                 logger.error("Permissions not set for app instance, using default.", exc_info=True)


### PR DESCRIPTION
## Description

https://scilifelab.slack.com/archives/C02L5Q7HWR1/p1713276097488319?thread_ts=1712926435.438649&cid=C02L5Q7HWR1

The problem was that when user had their app created before introduction of `link only` persmission option, they would get broken permissions in settings. This pr addresses this issue

## Checklist

_If you're unsure about any of the items below, don't hesitate to ask. We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [ x ] This pull request is against **develop** branch (not applicable for hotfixes)
- [ ] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [ ] I have included, reviewed and executed tests (unit and end2end) to complement my changes
- [ ] I have updated the related documentation (if necessary)
- [ x ] I have added a reviewer for this pull request
- [ x ] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts

## Further comments

Anything else you think we should know before merging your code!
