### PR TITLE
SS 1031 Type hints in studio

### DIFF
--- a/common/tasks.py
+++ b/common/tasks.py
@@ -1,4 +1,5 @@
 import time
+from typing import List
 
 from django.conf import settings
 from django.contrib.auth.models import Group, User
@@ -19,7 +20,7 @@ ADMIN_EMAIL = "serve@scilifelab.se"
 
 
 @app.task
-def handle_deleted_users():
+def handle_deleted_users() -> None:
     """
     Handles deleted user accounts.
 
@@ -65,7 +66,7 @@ def handle_deleted_users():
 
 
 @app.task
-def alert_pause_dormant_users():
+def alert_pause_dormant_users() -> None:
     """
     Handles dormant user accounts.
     The term dormant is used rather than inactive because of the overuse of the term inactive.
@@ -152,7 +153,7 @@ def alert_pause_dormant_users():
 
 
 @app.task(ignore_result=True)
-def send_email_task(subject, message, html_message, recipient_list):
+def send_email_task(subject: str, message: str, html_message: str, recipient_list: List[str]) -> None:
     logger.info("Sending email to %s", recipient_list)
     send_mail(
         subject,
@@ -164,7 +165,7 @@ def send_email_task(subject, message, html_message, recipient_list):
     )
 
 
-def send_verification_email_task(email, token):
+def send_verification_email_task(email: str, token: str) -> None:
     html_message = render_to_string(
         "registration/verify_email.html",
         {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   db:
     container_name: db

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,8 @@ black = { version = "==23.3.0", optional = true }
 isort = { version = "==5.12.0", optional = true }
 flake8 = { version = "==6.0.0", optional = true }
 mypy = { version = "==1.4.1", optional = true }
+#mypy = { version = "==1.10.0", optional = true }
+#django-stubs = { version = "==5.0.0", optional = true }
 hypothesis = { version = "==6.86.1", optional = true }
 moto = { version = "==4.*", extras = ["ec2", "s3", "all"], optional = true }
 pytest = { version = "~8.0.1", optional = true }
@@ -108,6 +110,26 @@ python_version = "3.12"
 ignore_missing_imports = false
 warn_return_any = true
 exclude = ["venv", ".venv", "examples"]
+#plugins = ["mypy_django_plugin.main"]
+
+#[tool.django-stubs]
+#django_settings_module = "studio.settings"
+
+[[tool.mypy.overrides]]
+module = "studio.*"
+#strict = true
+strict = false
+
+[[tool.mypy.overrides]]
+module = [
+	"*.tests.*",
+	"*.tests.py",
+	"cypress.*"
+]
+strict = false
+disallow_untyped_defs = false
+disallow_incomplete_defs = false
+check_untyped_defs = false
 
 [[tool.mypy.overrides]]
 module = "*.migrations.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ colorlog = "^6.8.2"
 black = { version = "==23.3.0", optional = true }
 isort = { version = "==5.12.0", optional = true }
 flake8 = { version = "==6.0.0", optional = true }
-mypy = { version = "==1.4.1", optional = true }
+mypy = { version = "==1.7.0", optional = true }
 #mypy = { version = "==1.10.0", optional = true }
 #django-stubs = { version = "==5.0.0", optional = true }
 hypothesis = { version = "==6.86.1", optional = true }
@@ -107,6 +107,7 @@ extend-exclude = '''
 [tool.mypy]
 strict = false
 python_version = "3.12"
+disallow_subclassing_any = false
 ignore_missing_imports = false
 warn_return_any = true
 exclude = ["venv", ".venv", "examples"]
@@ -117,23 +118,38 @@ exclude = ["venv", ".venv", "examples"]
 
 [[tool.mypy.overrides]]
 module = "studio.*"
-#strict = true
+strict = true
+disallow_subclassing_any = false
+disallow_untyped_decorators = false
+follow_imports_for_stubs = false
+
+[[tool.mypy.overrides]]
+module = "*.models"
 strict = false
+check_untyped_defs = false
+disallow_incomplete_defs = false
+disallow_subclassing_any = false
+disallow_untyped_defs = false
 
 [[tool.mypy.overrides]]
 module = [
 	"*.tests.*",
-	"*.tests.py",
+	"*.tests",
 	"cypress.*"
 ]
 strict = false
-disallow_untyped_defs = false
-disallow_incomplete_defs = false
 check_untyped_defs = false
+disallow_incomplete_defs = false
+disallow_untyped_defs = false
 
 [[tool.mypy.overrides]]
 module = "*.migrations.*"
 ignore_errors = true
+
+# A temporary section
+[[tool.mypy.overrides]]
+module = "common.tasks"
+disallow_untyped_decorators = false
 
 [[tool.mypy.overrides]]
 module = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,8 +104,8 @@ extend-exclude = '''
 
 [tool.mypy]
 strict = false
-python_version = "3.8"
-ignore_missing_imports = true
+python_version = "3.12"
+ignore_missing_imports = false
 warn_return_any = true
 exclude = ["venv", ".venv", "examples"]
 
@@ -115,14 +115,19 @@ ignore_errors = true
 
 [[tool.mypy.overrides]]
 module = [
+	"boto3.*",
+	"colorlog.*",
 	"django.*",
+	"django_structlog.*",
 	"rest_framework.*",
 	"flatten_json.*",
 	"guardian.*",
+	"hypothesis.*",
 	"django_filters.*",
 	"rest_framework_nested.*",
 	"tagulous.*",
 	"minio.*",
+	"moto.*",
 	"celery.*",
 	"dash.*",
 	"dash_core_components.*",
@@ -130,10 +135,12 @@ module = [
 	"django_plotly_dash.*",
 	"dash_bootstrap_components.*",
 	"markdown.*",
+	"pytest.*",
 	"pytz.*",
 	"requests.*",
 	"s3fs.*",
 	"setuptools.*",
+	"structlog.*",
 	"yaml.*",
 	]
 ignore_missing_imports = true

--- a/studio/celery.py
+++ b/studio/celery.py
@@ -16,7 +16,7 @@ app.config_from_object("django.conf:settings", namespace="CELERY")
 
 
 @setup_logging.connect
-def config_loggers(*args, **kwargs):
+def config_loggers(*args: object, **kwargs: object) -> None:
     logger_config = settings.LOGGING
     dictConfig(logger_config)
 

--- a/studio/helpers.py
+++ b/studio/helpers.py
@@ -6,7 +6,7 @@ from django.db import transaction
 from common.models import EmailVerificationTable
 
 
-def do_delete_account(user_id):
+def do_delete_account(user_id: int) -> bool:
     """
     Deletes a user account.
     Sets user.is_active = False and userprofile.deleted_on to now.
@@ -29,7 +29,7 @@ def do_delete_account(user_id):
     return user_account_deleted
 
 
-def do_pause_account(user_id):
+def do_pause_account(user_id: int) -> bool:
     """
     Sets a user account to pause (on hold).
     Sets user.is_active = False and deletes the user verification token if it exists.

--- a/studio/middleware.py
+++ b/studio/middleware.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 import traceback
+from typing import Any
 
 from studio.utils import get_logger
 
@@ -12,14 +13,14 @@ class ExceptionLoggingMiddleware:
     This middleware provides logging of exception in requests.
     """
 
-    def __init__(self, get_response):
+    def __init__(self, get_response: Any):
         self.get_response = get_response
 
-    def __call__(self, request):
+    def __call__(self, request: object) -> Any:
         response = self.get_response(request)
         return response
 
-    def process_exception(self, request, exception):
+    def process_exception(self, request: Any, exception: Any) -> None:
         """
         Processes exceptions during handling of a http request.
         Logs them with ERROR level.

--- a/studio/singleton.py
+++ b/studio/singleton.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Any, Dict
 
 
 class Singleton(type):
@@ -9,7 +9,7 @@ class Singleton(type):
 
     _instances: Dict[type, object] = {}
 
-    def __call__(cls, *args, **kwargs):
+    def __call__(cls: Any, *args, **kwargs) -> Any:  # type: ignore[no-untyped-def]
         if cls not in cls._instances:
             cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
         return cls._instances[cls]

--- a/studio/system_version.py
+++ b/studio/system_version.py
@@ -25,39 +25,39 @@ class SystemVersion(metaclass=Singleton):
     __pyproject_is_parsed = False
     __init_counter = 0
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs):  # type: ignore[no-untyped-def]
         self.__init_counter += 1
         self.__set_values_from_toml()
 
-    def get_version_text(self):
+    def get_version_text(self) -> str:
         """Gets a formatted text of the deployed system in format <date> (v0.0.0)."""
         if self.__build_date == "" or self.__gitref == "":
             return "unset"
         return f"{self.__build_date} ({self.__gitref})"
 
-    def get_build_date(self):
+    def get_build_date(self) -> str | None:
         """Gets the deployed system build date."""
         return self.__build_date
 
-    def get_gitref(self):
+    def get_gitref(self) -> str | None:
         """Gets the deployed system git reference, e.g. develop or v1.0.0."""
         return self.__gitref
 
-    def get_imagetag(self):
+    def get_imagetag(self) -> str | None:
         """Gets the deployed image tag as e.g. main-20230912"""
         return self.__imagetag
 
-    def get_debug_info(self):
+    def get_debug_info(self) -> str:
         debug_info = f"toml has been parsed:{self.__pyproject_is_parsed}, init:{self.__init_counter}"
         return debug_info
 
-    def get_init_counter(self):
+    def get_init_counter(self) -> int:
         return self.__init_counter
 
-    def get_pyproject_is_parsed(self):
+    def get_pyproject_is_parsed(self) -> bool:
         return self.__pyproject_is_parsed
 
-    def __set_values_from_toml(self):
+    def __set_values_from_toml(self) -> None:
         err_message = ""
         try:
             proj_path = pathlib.Path(__file__).parents[1] / "pyproject.toml"

--- a/studio/utils.py
+++ b/studio/utils.py
@@ -1,11 +1,11 @@
 import logging
-from typing import List
+from typing import Any, List
 
 import structlog
 from django.conf import settings
 
 
-def get_logger(name: str):
+def get_logger(name: str) -> Any:
     """
     Get different loggers depending on the value of DEBUG.
     When DEBUG = True, then we return the standard logger,
@@ -17,7 +17,7 @@ def get_logger(name: str):
         return structlog.getLogger(name)
 
 
-def add_loggers(logging: dict, installed_apps: List[str]) -> dict:
+def add_loggers(logging: dict[str, Any], installed_apps: List[str]) -> dict[str, Any]:
     """
     Helper function to add loggers to each installed app
     """

--- a/studio/version.py
+++ b/studio/version.py
@@ -1,5 +1,8 @@
+from typing import Any, List, Tuple
+
+
 class Version:
-    def __init__(self, version="v0.0.0"):
+    def __init__(self, version: str = "v0.0.0"):
         numbers = version[1:].split(".")
         self.major = int(numbers[0])
         self.minor = int(numbers[1])
@@ -9,7 +12,7 @@ class Version:
 
     # Release a new version
     # Default is new minor version
-    def release(self, release_type="minor"):
+    def release(self, release_type: str = "minor") -> Tuple[bool, str]:
         if release_type == "minor":
             self.minor = self.minor + 1
             self.patch = 0
@@ -26,7 +29,7 @@ class Version:
 
     # Implement comparison operators to allow for sorting
     # of models
-    def __gt__(self, other):
+    def __gt__(self, other: Any) -> bool:
         if self.major > other.major:
             return True
         elif other.major > self.major:
@@ -44,20 +47,20 @@ class Version:
 
         return False
 
-    def __eq__(self, other):
+    def __eq__(self, other: Any) -> bool:
         if self.major == other.major and self.minor == other.minor and self.patch == other.minor:
             return True
 
         return False
 
-    def __lt__(self, other):
+    def __lt__(self, other: Any) -> bool:
         if other.__gt__(self) or self.__eq__(other):
             return False
 
         return True
 
-    def release_types(self):
+    def release_types(self) -> List[str]:
         return ["major", "minor", "patch"]
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "v{}.{}.{}".format(self.major, self.minor, self.patch)


### PR DESCRIPTION
## Description

A PR to expand type hint coverage in the studio app and configure mypy to run more strictly in studio. Because of some particularities in how mypy overrides configurations between global and module-level settings, I have added mypy configuration in pyproject.toml that will eventually be removed. Also, I upgraded mypy to 1.7 to run with same version as is configured in the github action.

While extending type hinting and mypy strictness in studio, some special decisions are worth mentioning, namely:
- allow subclassing classes marked with Any
- allow untyped decorators

Jira [link](https://scilifelab.atlassian.net/browse/SS-1031)

## Checklist

- [x] This pull request is against **develop** branch (not applicable for hotfixes)
- [x] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [ ] I have included, reviewed and executed tests (unit and end2end) to complement my changes
- [ ] I have updated the related documentation (if necessary)
- [ ] I have added a reviewer for this pull request
- [x] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts
