### PR TITLE
SS-1401 Address missing Github api token

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -17,7 +17,7 @@ EVENT_USER_EMAIL=event_user@serve.scilifelab.se
 DEBUG=true
 INIT=true
 
-GITHUB_API_TOKEN=replace-me
+GITHUB_API_TOKEN=
 
 # This is an environment variable that deletes all data in database on start up of the app.
 # Its primary use is for deployment on remote development environment.

--- a/apps/helpers.py
+++ b/apps/helpers.py
@@ -506,6 +506,10 @@ def validate_ghcr_image(image: str):
     else:
         raise ValidationError("Could not recognise the GHCR owner. Please try again.")
 
+    # Return the image if the GitHub API token is missing
+    if settings.GITHUB_API_TOKEN in ["", None]:
+        return image
+
     headers = {"Authorization": f"Bearer {settings.GITHUB_API_TOKEN}", "Accept": "application/vnd.github+json"}
 
     try:

--- a/cypress/e2e/ui-tests/test-superuser-functionality.cy.js
+++ b/cypress/e2e/ui-tests/test-superuser-functionality.cy.js
@@ -469,7 +469,7 @@ describe("Test superuser access", () => {
             cy.get('input[name=name]').type(project_name)
             cy.get("input[name=save]").should('be.visible').contains('Create project').click()
         });
-        cy.wait(5000) // sometimes it takes a while to create a project but just waiting once at the end should be enough
+        cy.wait(10000) // sometimes it takes a while to create a project but just waiting once at the end should be enough
 
         cy.logf("Check that it is still possible to click the button to create a new project", Cypress.currentTest)
         cy.visit("/projects/")

--- a/cypress/e2e/ui-tests/test-user-manage-apps.cy.js
+++ b/cypress/e2e/ui-tests/test-user-manage-apps.cy.js
@@ -851,11 +851,21 @@ if (Cypress.env('create_resources') === true) {
             cy.get('tr:contains("' + app_name + '")').find('a').contains('Settings').click()
             cy.get('#id_image').type("-BAD")
             cy.get('#submit-id-submit').should('be.visible').contains('Submit').click()
-            // Stay on the Settings page
-            cy.url().should("include", "/apps/settings")
+            // Back on project page
+            cy.url().should("not.include", "/apps/settings")
+            cy.get('h3').should('have.text', project_name);
 
-            // Verify that the input field has the error class
-            cy.get('#id_image').should('have.class', 'is-invalid');
+            verifyAppStatus(app_name, "", "public", "Changing")
+
+            // The final app status and latest user action:
+            // Wait for 5 seconds and check the app status again
+            // This relies on the k8s event listener
+            // Verify that the app status now equals Error
+            if (env_run_extended_k8s_checks === true) {
+                cy.wait(5000).then(() => {
+                    verifyAppStatus(app_name, "Error", "public", "Changing")
+                })
+            }
 
             // Edit Dash app: modify the app image back to a valid image
             cy.logf("Editing the dash app settings field Image to a valid value", Cypress.currentTest)


### PR DESCRIPTION
## Description

Jira: https://scilifelab.atlassian.net/browse/SS-1401

E2E tests pass locally and fail on the GitHub workflow due to GHCR image validation issues. We suspect that the token is not set as an environment variable when the E2E tests run on GitHub.

Introduce code changes such that if the token is missing, do not validate the GHCR image.

## Checklist

_If you're unsure about any of the items below, don't hesitate to ask. We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [X] This pull request is against **develop** branch (not applicable for hotfixes)
- [X] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [X] I have included, reviewed and executed tests (unit and end2end) to complement my changes
- [ ] I have updated the related documentation (if necessary)
- [X] I have added a reviewer for this pull request
- [X] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts
