### PR TITLE
Fix SS-1481, Unable to create new MLFlow app instance

### DIFF
--- a/apps/models/app_types/mlflow.py
+++ b/apps/models/app_types/mlflow.py
@@ -42,7 +42,8 @@ class MLFlowInstance(BaseAppInstance):
             "pdb": {"create": False},
             # This fixes this issue:
             # https://mlflow.org/docs/2.21.3/tracking/server#handling-timeout-when-uploadingdownloading-large-artifacts
-            "extraArgs": {'--gunicorn-opts="--timeout=360"'},
+            # bug fix SS-1481, 'TypeError: Object of type set is not JSON serializable', changing set to list
+            "extraArgs": ['--gunicorn-opts="--timeout=360"'],
         }
         k8s_values["run"] = {
             "resources": {


### PR DESCRIPTION
## Status

Ready for review.

## Description

Source: https://scilifelab.atlassian.net/browse/SS-1481

The bug was a `TypeError: Object of type set is not JSON serializable` occurring when saving a Django model instance with a `JSONField`. The root cause was a Python set literal, `{'--gunicorn-opts="--timeout=360"'}` (missing a colon), being used for the `extraArgs` value in the `MLFlowInstance.get_k8s_values()` method.

The fix involved changing this incorrect `set` literal to a JSON-serializable `list` of strings: `['--gunicorn-opts="--timeout=360"']`.

Verification was performed by checking the `values.yaml` of the `bitnamicharts/mlflow` Helm chart ("oci://registry-1.docker.io/bitnamicharts/mlflow:2.5.2"), which confirmed that `extraArgs: [] `expects a list of strings, validating the chosen fix for compatibility with the Helm deployment.

## Types of changes

bugfix

## Checklist

_If you're unsure about any of the items below, don't hesitate to ask. We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [ ] This pull request is against **develop** branch (not applicable for hotfixes)
- [x] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [ ] I have included, reviewed and executed tests (unit and end2end) to complement my changes
- [ ] I have updated the related documentation (if necessary)
- [x] I have added a reviewer for this pull request
- [x] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts

## Further comments

Anything else you think we should know before merging your code!
