### PR TITLE
Fix: Ignore None docs on k8s manifest validation

### DIFF
--- a/apps/types_/kubernetes_deployment_manifest.py
+++ b/apps/types_/kubernetes_deployment_manifest.py
@@ -112,6 +112,8 @@ class KubernetesDeploymentManifest:
 
         # Now validate each manifest document
         for doc in documents:
+            if not doc:
+                continue
             try:
                 logger.debug(f"Validating document {doc['kind']}")
 


### PR DESCRIPTION
## Description

Error showing up possibly due to bad YAML formatting in the Helm chart.

```
2025-08-26 12:21:54 [error    ] task_failed                    error="'NoneType' object is not subscriptable" task_id=00c07b95-1ed8-4438-8578-3215ff3e37e0
Traceback (most recent call last):
  File "/app/apps/types_/kubernetes_deployment_manifest.py", line 116, in validate_manifest
    logger.debug(f"Validating document {doc['kind']}")
                                        ~~~^^^^^^^^
TypeError: 'NoneType' object is not subscriptable

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/celery/app/trace.py", line 477, in trace_task
    R = retval = fun(*args, **kwargs)
                 ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/celery/app/trace.py", line 760, in __protected_call__
    return self.run(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/contextlib.py", line 81, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/app/apps/tasks.py", line 245, in deploy_resource
    is_valid, validation_output, _ = kdm.validate_manifest(output)
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/apps/types_/kubernetes_deployment_manifest.py", line 129, in validate_manifest
    invalid_docs.append(doc["kind"])
                        ~~~^^^^^^^^
TypeError: 'NoneType' object is not subscriptable
2025-08-26 12:21:54 - ERROR - celery.app.trace: Task apps.tasks.deploy_resource[00c07b95-1ed8-4438-8578-3215ff3e37e0] raised unexpected: TypeError("'NoneType' object is not subscriptable")
Traceback (most recent call last):
  File "/app/apps/types_/kubernetes_deployment_manifest.py", line 116, in validate_manifest
    logger.debug(f"Validating document {doc['kind']}")
                                        ~~~^^^^^^^^
TypeError: 'NoneType' object is not subscriptable

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/celery/app/trace.py", line 477, in trace_task
    R = retval = fun(*args, **kwargs)
                 ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/celery/app/trace.py", line 760, in __protected_call__
    return self.run(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/contextlib.py", line 81, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/app/apps/tasks.py", line 245, in deploy_resource
    is_valid, validation_output, _ = kdm.validate_manifest(output)
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/apps/types_/kubernetes_deployment_manifest.py", line 129, in validate_manifest
    invalid_docs.append(doc["kind"])
```


## Checklist

_If you're unsure about any of the items below, don't hesitate to ask. We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [ ] This pull request is against **develop** branch (not applicable for hotfixes)
- [ ] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [ ] I have included, reviewed and executed tests (unit and end2end) to complement my changes
- [ ] I have updated the related documentation (if necessary)
- [ ] I have added a reviewer for this pull request
- [ ] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts

## Further comments

Anything else you think we should know before merging your code!
