### PR TITLE
SS-1778 Add nrm.se into the list of trusted affiliations

### DIFF
--- a/apps/helpers.py
+++ b/apps/helpers.py
@@ -881,6 +881,7 @@ def get_university_suffix_information(university_sufffix: str) -> str:
         "su": "Stockholms universitet (Stockholm University)",
         "umu": "Umeå universitet (Umeå University)",
         "uu": "Uppsala universitet (Uppsala University)",
+        "nrm": "The Swedish Museum of Natural History (Naturhistoriska riksmuseet)",
     }
 
     return UNIVERSITY_NAMES.get(university_sufffix, university_sufffix)

--- a/static/common/universities.json
+++ b/static/common/universities.json
@@ -25,6 +25,7 @@
     "mau": "Malm\u00f6 University",
     "mdu": "M\u00e4lardalen University",
     "miun": "Mid Sweden University",
+    "nrm": "The Swedish Museum of Natural History",
     "oru": "\u00d6rebro University",
     "other": "Other",
     "sh": "S\u00f6dert\u00f6rn University",

--- a/static/js/form-helpers.js
+++ b/static/js/form-helpers.js
@@ -4,7 +4,7 @@ window.onload = (event) => {
     const request_account_label = document.querySelector('label[for="id_why_account_needed"]');
     const department_label = document.querySelector('label[for="id_department"]');
 
-    const domainRegex = /^(?:(?!\b(?:student|stud)\b\.)[A-Z0-9](?:[\.A-Z0-9-]{0,61}[A-Z0-9])?\.)*?(uu|lu|gu|su|umu|liu|ki|kth|chalmers|ltu|hhs|slu|kau|lth|lnu|oru|miun|mau|mdu|bth|fhs|gih|hb|du|hig|hh|hkr|his|hv|ju|sh)\.se$/i;
+    const domainRegex = /^(?:(?!\b(?:student|stud)\b\.)[A-Z0-9](?:[\.A-Z0-9-]{0,61}[A-Z0-9])?\.)*?(uu|lu|gu|su|umu|liu|ki|kth|chalmers|ltu|hhs|slu|kau|lth|lnu|oru|miun|mau|mdu|bth|fhs|gih|hb|du|hig|hh|hkr|his|hv|ju|sh|nrm)\.se$/i;
 
     function changeVisibility() {
 


### PR DESCRIPTION
## Description

This PR solves SS-1778. We are letting people with the email (=affiliation) with the Swedish Natural History museum to use our service without the need for manual approval after registration.

## Checklist

_If you're unsure about any of the items below, don't hesitate to ask. We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] This pull request is against **develop** branch (not applicable for hotfixes)
- [x] I have included a link to the issue on GitHub or JIRA (if any)
- [x] I have included migration files (if there are changes to the model classes)
- [x] I have included, reviewed and executed tests (unit and end2end) to complement my changes
- [ ] I have updated the related documentation (if necessary)
- [ ] I have added a reviewer for this pull request
- [x] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts
- [ ] In case your changes are large enough, did you deploy your changes to develop instance?