### PR TITLE
ss-1796 Invenio subject only allows 1 of 2 subject fields

### DIFF
--- a/doi_minting/clients/invenio_client/invenio_client.py
+++ b/doi_minting/clients/invenio_client/invenio_client.py
@@ -131,51 +131,30 @@ class InvenioClient:
 
     # ==================== DRAFT RECORDS ====================
 
-    def create_draft(
-        self,
-        metadata: Dict[str, Any],
-        access: Optional[Dict[str, Any]] = None,
-        files: Optional[Dict[str, Any]] = None,
-        custom_fields: Optional[Dict[str, Any]] = None,
-        pids: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
+    def create_draft(self, record_data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Create a draft record
 
         Args:
-            metadata: Record metadata
-            access: Access options (record, files, embargo), "public" or "restricted"
-            files: Files options (enabled, default_preview, order)
-            custom_fields: Custom fields metadata (v10 and newer)
-            pids: Persistent identifiers (e.g., custom DOI)
+            record_data: Complete record data including metadata, access, files, and custom_fields
 
         Returns:
             Created draft record data
 
         Note:
             To provide your own DOI, include in pids field:
-            {"doi": {"identifier": "10.1234/your.doi", "provider": "external"}}
+            {"pids": {"doi": {"identifier": "10.1234/your.doi", "provider": "external"}}}
         """
         url = self._build_url("/api/records")
 
-        # Build request body
-        data = {"metadata": metadata}
+        # Use the complete record data directly
+        data = record_data.copy()
 
-        if access:
-            data["access"] = access
-        else:
+        # Ensure required fields have defaults if not present
+        if "access" not in data:
             data["access"] = {"record": "public", "files": "public"}
-
-        if files:
-            data["files"] = files
-        else:
+        if "files" not in data:
             data["files"] = {"enabled": False}
-
-        if custom_fields:
-            data["custom_fields"] = custom_fields
-
-        if pids:
-            data["pids"] = pids
 
         response = post(self.session, url, data=data, timeout=self.timeout)
         return self._handle_response(response, success_codes=[201])

--- a/doi_minting/clients/invenio_client/tests/test_invenio_client.py
+++ b/doi_minting/clients/invenio_client/tests/test_invenio_client.py
@@ -134,8 +134,8 @@ class TestDraftOperations:
 
         responses.add(responses.POST, url, json=expected_response, status=201)
 
-        metadata = {"title": "Test Draft"}
-        result = invenio_client.create_draft(metadata=metadata)
+        record_data = {"metadata": {"title": "Test Draft"}}
+        result = invenio_client.create_draft(record_data)
 
         assert result == expected_response
 
@@ -145,7 +145,7 @@ class TestDraftOperations:
         assert request.headers["Authorization"] == "Bearer test-token-12345"
 
         request_body = json.loads(request.body)
-        assert request_body["metadata"] == metadata
+        assert request_body["metadata"] == {"title": "Test Draft"}
         assert request_body["access"]["record"] == "public"
         assert request_body["files"]["enabled"] is False
 
@@ -157,17 +157,19 @@ class TestDraftOperations:
 
         responses.add(responses.POST, url, json=expected_response, status=201)
 
-        metadata = {"title": "Test"}
-        custom_fields = {"custom": "value"}
-        pids = {"doi": {"identifier": "10.1234/test", "provider": "external"}}
+        record_data = {
+            "metadata": {"title": "Test"},
+            "custom_fields": {"custom": "value"},
+            "pids": {"doi": {"identifier": "10.1234/test", "provider": "external"}},
+        }
 
-        result = invenio_client.create_draft(metadata=metadata, custom_fields=custom_fields, pids=pids)
+        result = invenio_client.create_draft(record_data)
 
         assert result == expected_response
 
         request_body = json.loads(responses.calls[0].request.body)
-        assert request_body["custom_fields"] == custom_fields
-        assert request_body["pids"] == pids
+        assert request_body["custom_fields"] == {"custom": "value"}
+        assert request_body["pids"] == {"doi": {"identifier": "10.1234/test", "provider": "external"}}
 
     @responses.activate
     def test_get_draft(self, invenio_client):

--- a/doi_minting/services/invenio_svc.py
+++ b/doi_minting/services/invenio_svc.py
@@ -155,8 +155,8 @@ class InvenioService:
         """
         logger.info(f"Creating new Invenio record for app: {app_instance.id}")
 
-        # Create draft
-        draft = self.client.create_draft(invenio_record.model_dump())
+        # Create draft - use mode="json" to ensure datetime objects are serialized as strings
+        draft = self.client.create_draft(invenio_record.model_dump(mode="json"))
         logger.debug(f"Created Invenio draft with ID: {draft['id']}")
 
         # Reserve DOI
@@ -196,7 +196,7 @@ class InvenioService:
         current_draft = self.client.get_draft(new_version["id"])
 
         # Update draft with new metadata
-        metadata_dict = metadata.model_dump()
+        metadata_dict = metadata.model_dump(mode="json")
         updated_metadata = {**metadata_dict}
 
         updated_version = self.client.update_draft(
@@ -274,7 +274,7 @@ class InvenioService:
                         language_objs.append(Language(id=lang))
             # If empty list, leave language_objs empty
         if language_objs:
-            target_metadata["languages"] = [lang.model_dump() for lang in language_objs]
+            target_metadata["languages"] = [lang.model_dump(mode="json") for lang in language_objs]
         else:
             target_metadata.pop("languages", None)
 

--- a/doi_minting/services/invenio_svc.py
+++ b/doi_minting/services/invenio_svc.py
@@ -290,57 +290,38 @@ class InvenioService:
             target_metadata.pop("languages", None)
 
         # Handle subject field (accept both 'subject' and 'subjects' as input)
-        subject: list[Subject] | None = None
-        if "subjects" in extra:
-            subject_input: Any = extra.get("subjects")
-            logger.debug(f"[Invenio] _apply_additional_invenio_metadata: subject_input={subject_input}")
-        elif "subject" in extra:
-            subject_input = extra.get("subject")
-            logger.debug(f"[Invenio] _apply_additional_invenio_metadata: subject_input={subject_input}")
-        else:
-            subject_input = None
+        subject_input = extra.get("subjects") or extra.get("subject")
 
-        if subject_input and isinstance(subject_input, list) and subject_input:
-            subject_terms: list[Subject] = []
+        if subject_input and isinstance(subject_input, list):
             try:
                 from .keywords_service import VocabularyMemoryService
 
                 vocab_service = VocabularyMemoryService()
             except Exception:
                 vocab_service = None
-            for tag in subject_input:
-                tag_label: str
-                if isinstance(tag, dict) and "label" in tag:
-                    tag_label = tag["label"]
-                elif isinstance(tag, str):
-                    tag_label = tag
-                else:
-                    continue
-                subject_term = None
-                if vocab_service:
+
+            subject_terms = []
+            if vocab_service:
+                for tag in subject_input:
+                    # Extract tag label
+                    tag_label = str(tag) if isinstance(tag, str) else None
+                    if not tag_label:
+                        continue
+
+                    # Find matching vocabulary term
                     for term_id, term_data in vocab_service.term_metadata.items():
-                        subj = term_data.subject or ""
-                        if isinstance(subj, str) and subj.lower() == tag_label.lower():
-                            # Use the vocabulary data but override subject with tag_label
-                            vocab_data = term_data.model_dump()
-                            vocab_data["subject"] = tag_label
-                            # Filter out None values to prevent validation errors
-                            vocab_data = {k: v for k, v in vocab_data.items() if v is not None}
-                            subject_term = Subject(**vocab_data)
+                        if term_data.subject and term_data.subject.lower() == tag_label.lower():
+                            subject_term = Subject(
+                                subject=tag_label,
+                                scheme=term_data.subject_scheme or "NA",
+                                url=term_data.scheme_uri or "NA",
+                                identifier=term_data.classification_code or tag_label.lower().replace(" ", "_"),
+                                lang=term_data.lang or "en",
+                            )
+                            subject_terms.append(subject_term)
                             break
-                if not subject_term:
-                    subject_term = Subject(subject=tag_label)
-                subject_terms.append(subject_term)
-            logger.debug(f"[Invenio] _apply_additional_invenio_metadata: subject_terms={subject_terms}")
-            if subject_terms:
-                subject = subject_terms
 
-        if subject:
-            # Convert Subject objects to dicts for serialization
-            subject_dicts = [s.model_dump() for s in subject if hasattr(s, "model_dump")]
-            # Also store as Subject objects for downstream use
-
-            target_metadata["subjects"] = [Subject(**s) if not isinstance(s, Subject) else s for s in subject_dicts]
+            target_metadata["subjects"] = subject_terms if subject_terms else None
         else:
             target_metadata.pop("subjects", None)
         logger.debug(f"Applied additional metadata: {extra}. Resulting metadata: {target_metadata}")
@@ -499,7 +480,7 @@ class InvenioService:
 
         # Log the generated metadata
         logger.info(f"Generated Invenio metadata for app '{app_data.name}'")
-        logger.info(json.dumps(invenio_record.model_dump(by_alias=True), indent=2))
+        logger.info(json.dumps(invenio_record.model_dump(), indent=2))
 
         return invenio_record
 

--- a/doi_minting/services/invenio_svc.py
+++ b/doi_minting/services/invenio_svc.py
@@ -140,18 +140,14 @@ class InvenioService:
     def create_new_record(
         self,
         app_instance: Any,
-        metadata: InvenioMetadata,
-        access: AccessConfig,
-        custom_fields: Optional[Dict[str, Any]] = None,
+        invenio_record: InvenioRecord,
     ) -> Dict[str, Any]:
         """
         Create a new Invenio record for the application.
 
         Args:
             app_instance: The application instance
-            metadata: Invenio metadata
-            access: Access configuration
-            custom_fields: Optional custom fields
+            invenio_record: Complete Invenio record object with metadata, access, and files config
 
         Returns:
             Published record data
@@ -159,12 +155,7 @@ class InvenioService:
         logger.info(f"Creating new Invenio record for app: {app_instance.id}")
 
         # Create draft
-        draft = self.client.create_draft(
-            metadata=metadata.model_dump(),
-            access=access.model_dump(),
-            custom_fields=custom_fields,
-            files={"enabled": False},  # Explicitly set for metadata-only
-        )
+        draft = self.client.create_draft(invenio_record.model_dump())
         logger.debug(f"Created Invenio draft with ID: {draft['id']}")
 
         # Reserve DOI
@@ -308,18 +299,27 @@ class InvenioService:
                     if not tag_label:
                         continue
 
+                    found_match = False
                     # Find matching vocabulary term
+                    # TODO - Include term ID/URI in subject when vocab is configured in our Invenio instance
                     for term_id, term_data in vocab_service.term_metadata.items():
                         if term_data.subject and term_data.subject.lower() == tag_label.lower():
-                            subject_term = Subject(
-                                subject=tag_label,
-                                scheme=term_data.subject_scheme or "NA",
-                                url=term_data.scheme_uri or "NA",
-                                identifier=term_data.classification_code or tag_label.lower().replace(" ", "_"),
-                                lang=term_data.lang or "en",
-                            )
+                            subject_term = Subject(subject=tag_label)
                             subject_terms.append(subject_term)
+                            found_match = True
                             break
+
+                    # If no vocabulary match found, use as free text subject
+                    if not found_match:
+                        subject_term = Subject(subject=tag_label)
+                        subject_terms.append(subject_term)
+            else:
+                # If no vocabulary service, use all as free text subjects
+                for tag in subject_input:
+                    tag_label = str(tag) if isinstance(tag, str) else None
+                    if tag_label:
+                        subject_term = Subject(subject=tag_label)
+                        subject_terms.append(subject_term)
 
             target_metadata["subjects"] = subject_terms if subject_terms else None
         else:
@@ -480,7 +480,6 @@ class InvenioService:
 
         # Log the generated metadata
         logger.info(f"Generated Invenio metadata for app '{app_data.name}'")
-        logger.info(json.dumps(invenio_record.model_dump(), indent=2))
 
         return invenio_record
 
@@ -559,15 +558,14 @@ class InvenioService:
             invenio_record: InvenioRecord = self.generate_invenio_metadata(
                 app_instance, additional_metadata=additional_metadata
             )
-            metadata: InvenioMetadata = invenio_record.metadata
-            access = invenio_record.access
-            custom_fields = None  # Not currently used
 
             # Create or update record
+            logger.info(f"About to create or update Invenio record for app '{app_data.name}'")
+            logger.info(json.dumps(invenio_record.model_dump(), indent=2))
             if not app_instance.invenio_record_id or app_instance.invenio_record_id == "":
-                published_record = self.create_new_record(app_instance, metadata, access, custom_fields)
+                published_record = self.create_new_record(app_instance, invenio_record)
             else:
-                published_record = self.create_new_version(app_instance, metadata)
+                published_record = self.create_new_version(app_instance, invenio_record.metadata)
 
             # Extract DOI and update app instance
             published_doi = published_record.get("pids", {}).get("doi", {}).get("identifier", "")

--- a/doi_minting/services/schemas.py
+++ b/doi_minting/services/schemas.py
@@ -125,13 +125,10 @@ class RelatedIdentifierItem(BaseModel):
 
 
 class Subject(BaseModel):
-    """Subject/keyword term with full metadata for Invenio subject field."""
+    """Subject/keyword term for Invenio subject field."""
 
-    subject: str
-    scheme: str
-    url: str
-    identifier: str
-    lang: str = "en"
+    id: str | None = None  # Controlled vocabulary identifier URI
+    subject: str | None = None  # Free text keyword
 
 
 class AutocompleteTerm(BaseModel):

--- a/doi_minting/services/schemas.py
+++ b/doi_minting/services/schemas.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from typing import Any, List, TypedDict
 
-from pydantic import AliasChoices, BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict
 
 
 class AdditionalMetadata(TypedDict, total=False):
@@ -128,13 +128,9 @@ class Subject(BaseModel):
     """Subject/keyword term with full metadata for Invenio subject field."""
 
     subject: str
-    scheme: str = Field(
-        default="", alias="subjectSchema", validation_alias=AliasChoices("scheme", "subjectSchema", "subject_scheme")
-    )
-    url: str = Field(default="", alias="valueURI", validation_alias=AliasChoices("url", "valueURI", "value_uri"))
-    identifier: str = Field(
-        default="", validation_alias=AliasChoices("identifier", "classificationCode", "classification_code")
-    )
+    scheme: str
+    url: str
+    identifier: str
     lang: str = "en"
 
 
@@ -152,14 +148,9 @@ class TermMetadata(BaseModel):
 
     subject: str | None = None
     subject_scheme: str | None = None
-    subjectScheme: str | None = None
     scheme_uri: str | None = None
-    schemeURI: str | None = None
     value_uri: str | None = None
-    valueURI: str | None = None
     classification_code: str | None = None
-    classificationCode: str | None = None
-    label: str | None = None
     lang: str | None = None
 
 


### PR DESCRIPTION
## Description

Jira: https://scilifelab.atlassian.net/browse/SS-1796

Subjects in the DOI record are not showing all fields existing in the Invenio record. It appears that the Invenio subject object is allowed to have `id` or `subject` as mentioned [here](https://inveniordm.docs.cern.ch/reference/metadata/#subjects).

This PR:

* changes the Subject Pydantic model to have only 2 fields
* makes the `self.create_new_record` method use the Invenio record object when minting
* adds a TODO to use subject `id` in the future when vocab entries get configured to our Invenio instance

## Checklist

> If you're unsure about any of the items below, don't hesitate to ask. We're here to help!
> This is simply a reminder of what we are going to look for before merging your code.

- [X] This pull request is against **develop** branch (not applicable for hotfixes)
- [X] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [ ] I have added or updated unit and end2end tests to complement my changes
- [ ] I have ran unit and end2end tests
- [ ] I have updated the related documentation (if necessary)
- [x] I have added a reviewer for this pull request
- [X] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts
- [ ] In case your changes are large enough, did you deploy your changes to develop instance?

# PR cheatsheet

- PR -- pull request
- Include jira ticket in the PR title (like `SS-1234 Introduced machine learning ai driven framework for DDLS Fellows from EMBL`)
- To set the status of the pull request, use the built-in github feature to set the PR as Draft or Ready for review.
- To indicate the type of change (such as bugfix or new feature), use a github pull request label.
- If pr is not ready for review, set it draft. We agreed in the team, that if the PR in the draft state, no one will review it.
- Remember, that you can trigger end2end tests manually
