### PR TITLE
ss-1795 Allow comma-separated keywords in app form

### DIFF
--- a/apps/forms/mixins.py
+++ b/apps/forms/mixins.py
@@ -160,7 +160,7 @@ class KeywordTagsValidationMixin:
         """Validate the invenio_tags input against the autocomplete API."""
         print("clean_keyword_tags called")
         tags_value = self.cleaned_data.get("invenio_tags", "").strip()
-        tags_list = [tag.strip() for tag in tags_value.split(",") if tag.strip()]
+        tags_list = [tag.strip() for tag in tags_value.split("|") if tag.strip()]
         if not tags_list:
             tags_list = [tag.strip() for tag in tags_value.split() if tag.strip()]
 

--- a/apps/tests/test_app_helper_utils.py
+++ b/apps/tests/test_app_helper_utils.py
@@ -59,7 +59,7 @@ class CreateAppInstanceTestCase(TestCase):
             "port": 8000,
             "image": "some-image",
             "source_code_url": "https://someurlthatdoesnotexist.com",
-            "invenio_tags": "Antibodies, Cells",
+            "invenio_tags": "Antibodies|Cells",
         }
 
         _, form_class = APP_REGISTRY.get(self.app_slug)
@@ -200,7 +200,7 @@ class UpdateExistingAppInstanceTestCase(TestCase):
             "source_code_url": self.source_code_url,
             "subdomain": self.subdomain_name,
             "language": "eng",
-            "invenio_tags": "Antibodies, Cells",
+            "invenio_tags": "Antibodies|Cells",
         }
 
         changed_fields = ["port", "invenio_tags", "tags"]
@@ -231,7 +231,7 @@ class UpdateExistingAppInstanceTestCase(TestCase):
             "image": "test-image-new",
             "source_code_url": self.source_code_url,
             "subdomain": self.subdomain_name,
-            "invenio_tags": "Antibodies, Cells",
+            "invenio_tags": "Antibodies|Cells",
         }
 
         changed_fields = ["image", "invenio_tags", "tags"]
@@ -263,7 +263,7 @@ class UpdateExistingAppInstanceTestCase(TestCase):
             "image": self.image,
             "source_code_url": self.source_code_url,
             "subdomain": "test-subdomain-update-app-new",
-            "invenio_tags": "Antibodies, Cells",
+            "invenio_tags": "Antibodies|Cells",
         }
 
         changed_fields = ["subdomain", "invenio_tags", "tags"]
@@ -302,7 +302,7 @@ class UpdateExistingAppInstanceTestCase(TestCase):
             "image": self.image,
             "source_code_url": "https://someurlthatdoesnotexist.com/new",
             "subdomain": self.subdomain_name,
-            "invenio_tags": "Antibodies, Cells",
+            "invenio_tags": "Antibodies|Cells",
         }
 
         changed_fields = ["name", "description", "source_code_url", "invenio_tags", "tags"]
@@ -390,7 +390,7 @@ class UpdateExistingAppInstanceTestCase(TestCase):
             "image": self.image,
             "source_code_url": self.source_code_url,
             "subdomain": self.subdomain_name,
-            "invenio_tags": "Antibodies, Cells",
+            "invenio_tags": "Antibodies|Cells",
         }
         form = form_class(data, project_pk=self.project.pk, instance=app_instance)
         self.assertTrue(form.is_valid(), f"The form should be valid but has errors: {form.errors}")
@@ -430,7 +430,7 @@ def test_get_subdomain_name():
         "image": "some-image",
         "source_code_url": "https://someurlthatdoesnotexist.com",
         "subdomain": subdomain,
-        "invenio_tags": "Antibodies, Cells",
+        "invenio_tags": "Antibodies|Cells",
     }
 
     _, form_class = APP_REGISTRY.get("dashapp")
@@ -461,7 +461,7 @@ def test_get_subdomain_name_no_subdomain_in_form():
         "port": 9999,
         "image": "some-image",
         "source_code_url": "https://someurlthatdoesnotexist.com",
-        "invenio_tags": "Antibodies, Cells",
+        "invenio_tags": "Antibodies|Cells",
     }
 
     _, form_class = APP_REGISTRY.get("dashapp")

--- a/apps/tests/test_forms.py
+++ b/apps/tests/test_forms.py
@@ -54,7 +54,7 @@ class CustomAppFormTest(BaseAppFormTest):
             "image": "mock.io/scilifelabdatacentre/image:tag",
             "default_url_subpath": "valid-default_url_subpath/",
             # These tags are found in the vocabulary service pickled data.
-            "invenio_tags": "Antibodies, Chemistry, Cats",
+            "invenio_tags": "Antibodies|Chemistry|Cats",
         }
 
     def test_form_valid_data(self):
@@ -122,7 +122,7 @@ class CustomAppFormRenderingTest(BaseAppFormTest):
             "port": 8000,
             "image": "ghcr.io/scilifelabdatacentre/image:tag",
             # These tags are found in the vocabulary service pickled data.
-            "invenio_tags": "Antibodies, Chemistry, Cats",
+            "invenio_tags": "Antibodies|Chemistry|Cats",
         }
 
     def test_form_rendering(self):

--- a/apps/tests/test_forms.py
+++ b/apps/tests/test_forms.py
@@ -134,7 +134,7 @@ class CustomAppFormRenderingTest(BaseAppFormTest):
         rendered_form = template.render(context)
         for key, value in valid_data.items():
             if key == "invenio_tags":
-                value = "Antibodies, Chemistry, Cats"
+                value = "Antibodies|Chemistry|Cats"
             if key == "mount_path":  # Form uses mount_path instead of volume
                 value = self.valid_data.get("path")  # Mount path is same as path in the form
             if key == "flavor":

--- a/templates/apps/create_base.html
+++ b/templates/apps/create_base.html
@@ -309,7 +309,7 @@ document.addEventListener("DOMContentLoaded", function() {
         let validSuggestions = [];
 
         function updateHiddenField() {
-            invenioTagsField.value = currentTags.join(', ');
+            invenioTagsField.value = currentTags.join('|');
         }
 
         function addTag(tagText) {
@@ -452,7 +452,7 @@ document.addEventListener("DOMContentLoaded", function() {
         // Initialize with existing values if any
         const existingValue = invenioTagsField.value.trim();
         if (existingValue) {
-            currentTags = existingValue.split(',').map(tag => tag.trim()).filter(tag => tag);
+            currentTags = existingValue.split('|').map(tag => tag.trim()).filter(tag => tag);
             renderTags();
         }
     });


### PR DESCRIPTION
## Description

Jira: https://scilifelab.atlassian.net/browse/SS-1795

In the "create app" form, allow the user to choose keywords containing commas. The tag validation on the backend should split tags on a character other than `,` to allow this to happen.

## Checklist

> If you're unsure about any of the items below, don't hesitate to ask. We're here to help!
> This is simply a reminder of what we are going to look for before merging your code.

- [X] This pull request is against **develop** branch (not applicable for hotfixes)
- [X] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [ ] I have added or updated unit and end2end tests to complement my changes
- [ ] I have ran unit and end2end tests
- [ ] I have updated the related documentation (if necessary)
- [X] I have added a reviewer for this pull request
- [X] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts
- [ ] In case your changes are large enough, did you deploy your changes to develop instance?

# PR cheatsheet

- PR -- pull request
- Include jira ticket in the PR title (like `SS-1234 Introduced machine learning ai driven framework for DDLS Fellows from EMBL`)
- To set the status of the pull request, use the built-in github feature to set the PR as Draft or Ready for review.
- To indicate the type of change (such as bugfix or new feature), use a github pull request label.
- If pr is not ready for review, set it draft. We agreed in the team, that if the PR in the draft state, no one will review it.
- Remember, that you can trigger end2end tests manually
