### PR TITLE
ss-1802 Add creator field in Serve app forms (on the backend)

### DIFF
--- a/apps/forms/base.py
+++ b/apps/forms/base.py
@@ -37,6 +37,7 @@ class BaseForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         self.project_pk = kwargs.pop("project_pk", None)
+        self.request = kwargs.pop("request", None)  # Store request for mixins
         self.project = get_object_or_404(Project, pk=self.project_pk) if self.project_pk else None
         self.model_name = self._meta.model._meta.verbose_name.replace("Instance", "")
 

--- a/apps/forms/custom.py
+++ b/apps/forms/custom.py
@@ -10,6 +10,7 @@ from apps.forms.base import AppBaseForm
 from apps.forms.field.common import SRVCommonDivField
 from apps.forms.mixins import (
     ContainerImageMixin,
+    CreatorsMixin,
     KeywordTagsValidationMixin,
     StorageMixin,
 )
@@ -19,7 +20,7 @@ from projects.models import Flavor
 __all__ = ["CustomAppForm"]
 
 
-class CustomAppForm(StorageMixin, ContainerImageMixin, KeywordTagsValidationMixin, AppBaseForm):
+class CustomAppForm(StorageMixin, ContainerImageMixin, KeywordTagsValidationMixin, CreatorsMixin, AppBaseForm):
     flavor = forms.ModelChoiceField(queryset=Flavor.objects.none(), required=False, empty_label=None)
     port = forms.IntegerField(min_value=3000, max_value=9999, required=True)
     path = forms.CharField(max_length=255, required=False)
@@ -43,6 +44,19 @@ class CustomAppForm(StorageMixin, ContainerImageMixin, KeywordTagsValidationMixi
             "We allow keywords from MeSH, EuroSciVoc, and GEMET.",
             widget=forms.TextInput(attrs={"class": "form-control"}),
         )
+
+        self.fields["creators"] = forms.CharField(
+            required=False,
+            label="Creators",
+            help_text=(
+                "Manage the creators of this app. You are included as the primary creator by default. "
+                "You can add, edit, remove, and reorder creators as needed."
+            ),
+            widget=forms.HiddenInput(),  # Will be handled by custom template
+        )
+
+        # Initialize creators with current user if available
+        self._initialize_creators()
 
     def _setup_form_fields(self):
         # Handle Volume field
@@ -87,7 +101,7 @@ class CustomAppForm(StorageMixin, ContainerImageMixin, KeywordTagsValidationMixi
         ]
 
         general = AccordionGroup(
-            mark_safe("<h3>Description</h3>"),
+            mark_safe("<h3>About</h3>"),
             *general_fields,
             active=True,
         )

--- a/apps/forms/dash.py
+++ b/apps/forms/dash.py
@@ -8,14 +8,18 @@ from django.utils.safestring import mark_safe
 
 from apps.forms.base import AppBaseForm
 from apps.forms.field.common import SRVCommonDivField
-from apps.forms.mixins import ContainerImageMixin, KeywordTagsValidationMixin
+from apps.forms.mixins import (
+    ContainerImageMixin,
+    CreatorsMixin,
+    KeywordTagsValidationMixin,
+)
 from apps.models import DashInstance
 from projects.models import Flavor
 
 __all__ = ["DashForm"]
 
 
-class DashForm(ContainerImageMixin, KeywordTagsValidationMixin, AppBaseForm):
+class DashForm(ContainerImageMixin, CreatorsMixin, KeywordTagsValidationMixin, AppBaseForm):
     flavor = forms.ModelChoiceField(queryset=Flavor.objects.none(), required=False, empty_label=None)
     port = forms.IntegerField(min_value=3000, max_value=9999, required=True)
     default_url_subpath = forms.CharField(max_length=255, required=False, label="Custom URL subpath")
@@ -38,6 +42,19 @@ class DashForm(ContainerImageMixin, KeywordTagsValidationMixin, AppBaseForm):
             "We allow keywords from MeSH, EuroSciVoc, and GEMET.",
             widget=forms.TextInput(attrs={"class": "form-control"}),
         )
+
+        self.fields["creators"] = forms.CharField(
+            required=False,
+            label="Creators",
+            help_text=(
+                "Manage the creators of this app. You are included as the primary creator by default. "
+                "You can add, edit, remove, and reorder creators as needed."
+            ),
+            widget=forms.HiddenInput(),  # Will be handled by custom template
+        )
+
+        # Initialize creators with current user if available
+        self._initialize_creators()
 
     def _setup_form_fields(self):
         # Handle Volume field

--- a/apps/forms/depictio.py
+++ b/apps/forms/depictio.py
@@ -6,13 +6,13 @@ from django.utils.safestring import mark_safe
 
 from apps.forms.base import BaseForm
 from apps.forms.field.common import SRVCommonDivField
-from apps.forms.mixins import KeywordTagsValidationMixin
+from apps.forms.mixins import CreatorsMixin, KeywordTagsValidationMixin
 from apps.models import DepictioInstance
 
 __all__ = ["DepictioForm"]
 
 
-class DepictioForm(KeywordTagsValidationMixin, BaseForm):
+class DepictioForm(KeywordTagsValidationMixin, CreatorsMixin, BaseForm):
     def _setup_form_fields(self):
         super()._setup_form_fields()
 
@@ -24,6 +24,19 @@ class DepictioForm(KeywordTagsValidationMixin, BaseForm):
             "We allow keywords from MeSH, EuroSciVoc, and GEMET.",
             widget=forms.TextInput(attrs={"class": "form-control"}),
         )
+
+        self.fields["creators"] = forms.CharField(
+            required=False,
+            label="Creators",
+            help_text=(
+                "Manage the creators of this app. You are included as the primary creator by default. "
+                "You can add, edit, remove, and reorder creators as needed."
+            ),
+            widget=forms.HiddenInput(),  # Will be handled by custom template
+        )
+
+        # Initialize creators with current user if available
+        self._initialize_creators()
 
     def _setup_form_helper(self):
         super()._setup_form_helper()

--- a/apps/forms/gradio.py
+++ b/apps/forms/gradio.py
@@ -8,6 +8,7 @@ from apps.forms.base import AppBaseForm
 from apps.forms.field.common import SRVCommonDivField
 from apps.forms.mixins import (
     ContainerImageMixin,
+    CreatorsMixin,
     KeywordTagsValidationMixin,
     StorageMixin,
 )
@@ -17,7 +18,7 @@ from projects.models import Flavor
 __all__ = ["GradioForm"]
 
 
-class GradioForm(StorageMixin, ContainerImageMixin, KeywordTagsValidationMixin, AppBaseForm):
+class GradioForm(StorageMixin, ContainerImageMixin, KeywordTagsValidationMixin, CreatorsMixin, AppBaseForm):
     flavor = forms.ModelChoiceField(queryset=Flavor.objects.none(), required=False, empty_label=None)
     port = forms.IntegerField(min_value=3000, max_value=9999, required=True)
     path = forms.CharField(max_length=255, required=False)
@@ -40,6 +41,19 @@ class GradioForm(StorageMixin, ContainerImageMixin, KeywordTagsValidationMixin, 
             "We allow keywords from MeSH, EuroSciVoc, and GEMET.",
             widget=forms.TextInput(attrs={"class": "form-control"}),
         )
+
+        self.fields["creators"] = forms.CharField(
+            required=False,
+            label="Creators",
+            help_text=(
+                "Manage the creators of this app. You are included as the primary creator by default. "
+                "You can add, edit, remove, and reorder creators as needed."
+            ),
+            widget=forms.HiddenInput(),  # Will be handled by custom template
+        )
+
+        # Initialize creators with current user if available
+        self._initialize_creators()
 
     def _setup_form_fields(self):
         # Handle Volume field

--- a/apps/forms/mixins.py
+++ b/apps/forms/mixins.py
@@ -190,7 +190,12 @@ class CreatorsMixin:
         else:
             logger.warning("CreatorsMixin: No request or user object available")
 
-        self.fields["creators"].initial = json.dumps(creators_data)
+        # Only set initial value if we have creator data to avoid marking field as changed
+        if creators_data:
+            logger.info(f"CreatorsMixin: Setting creators initial data: {creators_data}")
+            self.fields["creators"].initial = json.dumps(creators_data)
+        else:
+            logger.info("CreatorsMixin: No creator data, leaving field initial value unchanged")
 
     def get_creators_data(self):
         """Get the parsed creators data from the form."""

--- a/apps/forms/mixins.py
+++ b/apps/forms/mixins.py
@@ -167,35 +167,24 @@ class CreatorsMixin:
 
         creators_data = []
 
-        if self.request and hasattr(self.request, "user"):
-            if self.request.user.is_authenticated:
-                user = self.request.user
-                user_name = f"{user.first_name} {user.last_name}".strip() or user.username
-
-                logger.info(
-                    f"CreatorsMixin: User details - ID: {user.pk}, Username: {user.username}, "
-                    f"Name: '{user_name}', Email: {user.email}"
-                )
-
-                primary_creator = {
-                    "name": user_name,
+        if (
+            hasattr(self, "request")
+            and self.request
+            and getattr(self.request, "user", None)
+            and self.request.user.is_authenticated
+        ):
+            user = self.request.user
+            creators_data = [
+                {
+                    "name": user.get_full_name() or user.username,
                     "email": user.email,
                     "affiliation": "",
                     "orcid": "",
                     "order": 0,
                 }
-                creators_data.append(primary_creator)
-            else:
-                logger.warning("CreatorsMixin: User is not authenticated, no creator added")
-        else:
-            logger.warning("CreatorsMixin: No request or user object available")
-
-        # Only set initial value if we have creator data to avoid marking field as changed
-        if creators_data:
-            logger.info(f"CreatorsMixin: Setting creators initial data: {creators_data}")
+            ]
+            logger.debug(f"Initialized creators with current user: {creators_data}")
             self.fields["creators"].initial = json.dumps(creators_data)
-        else:
-            logger.info("CreatorsMixin: No creator data, leaving field initial value unchanged")
 
     def get_creators_data(self):
         """Get the parsed creators data from the form."""
@@ -203,7 +192,8 @@ class CreatorsMixin:
 
         creators_json = self.cleaned_data.get("creators", "[]")
         try:
-            return json.loads(creators_json) if creators_json else []
+            creators_data = json.loads(creators_json) if creators_json else []
+            return creators_data
         except (json.JSONDecodeError, TypeError):
             return []
 

--- a/apps/forms/mixins.py
+++ b/apps/forms/mixins.py
@@ -155,6 +155,54 @@ class VolumeMixin:
         return SRVCommonDivField("volume", template="apps/storage_field.html", project_slug=self.project.slug)
 
 
+class CreatorsMixin:
+    """Mixin to add creators field functionality for managing app creators."""
+
+    def _initialize_creators(self):
+        """Initialize the creators field with the current user as the primary creator."""
+        import json
+        import logging
+
+        logger = logging.getLogger(__name__)
+
+        creators_data = []
+
+        if self.request and hasattr(self.request, "user"):
+            if self.request.user.is_authenticated:
+                user = self.request.user
+                user_name = f"{user.first_name} {user.last_name}".strip() or user.username
+
+                logger.info(
+                    f"CreatorsMixin: User details - ID: {user.pk}, Username: {user.username}, "
+                    f"Name: '{user_name}', Email: {user.email}"
+                )
+
+                primary_creator = {
+                    "name": user_name,
+                    "email": user.email,
+                    "affiliation": "",
+                    "orcid": "",
+                    "order": 0,
+                }
+                creators_data.append(primary_creator)
+            else:
+                logger.warning("CreatorsMixin: User is not authenticated, no creator added")
+        else:
+            logger.warning("CreatorsMixin: No request or user object available")
+
+        self.fields["creators"].initial = json.dumps(creators_data)
+
+    def get_creators_data(self):
+        """Get the parsed creators data from the form."""
+        import json
+
+        creators_json = self.cleaned_data.get("creators", "[]")
+        try:
+            return json.loads(creators_json) if creators_json else []
+        except (json.JSONDecodeError, TypeError):
+            return []
+
+
 class KeywordTagsValidationMixin:
     def clean_keyword_tags(self):
         """Validate the invenio_tags input against the autocomplete API."""

--- a/apps/forms/shiny.py
+++ b/apps/forms/shiny.py
@@ -9,6 +9,7 @@ from apps.forms.base import AppBaseForm
 from apps.forms.field.common import SRVCommonDivField
 from apps.forms.mixins import (
     ContainerImageMixin,
+    CreatorsMixin,
     KeywordTagsValidationMixin,
     StorageMixin,
 )
@@ -18,7 +19,7 @@ from projects.models import Flavor
 __all__ = ["ShinyForm"]
 
 
-class ShinyForm(StorageMixin, ContainerImageMixin, KeywordTagsValidationMixin, AppBaseForm):
+class ShinyForm(StorageMixin, ContainerImageMixin, KeywordTagsValidationMixin, CreatorsMixin, AppBaseForm):
     flavor = forms.ModelChoiceField(queryset=Flavor.objects.none(), required=False, empty_label=None)
     port = forms.IntegerField(min_value=3000, max_value=9999, required=True)
     shiny_site_dir = forms.CharField(max_length=255, required=False, label="Path to site_dir")
@@ -40,6 +41,19 @@ class ShinyForm(StorageMixin, ContainerImageMixin, KeywordTagsValidationMixin, A
             "We allow keywords from MeSH, EuroSciVoc, and GEMET.",
             widget=forms.TextInput(attrs={"class": "form-control"}),
         )
+
+        self.fields["creators"] = forms.CharField(
+            required=False,
+            label="Creators",
+            help_text=(
+                "Manage the creators of this app. You are included as the primary creator by default. "
+                "You can add, edit, remove, and reorder creators as needed."
+            ),
+            widget=forms.HiddenInput(),  # Will be handled by custom template
+        )
+
+        # Initialize creators with current user if available
+        self._initialize_creators()
 
         if self.instance and self.instance.pk:
             self.initial_subdomain = self.instance.subdomain.subdomain

--- a/apps/forms/streamlit.py
+++ b/apps/forms/streamlit.py
@@ -8,6 +8,7 @@ from apps.forms.base import AppBaseForm
 from apps.forms.field.common import SRVCommonDivField
 from apps.forms.mixins import (
     ContainerImageMixin,
+    CreatorsMixin,
     KeywordTagsValidationMixin,
     StorageMixin,
 )
@@ -17,7 +18,7 @@ from projects.models import Flavor
 __all__ = ["StreamlitForm"]
 
 
-class StreamlitForm(StorageMixin, ContainerImageMixin, KeywordTagsValidationMixin, AppBaseForm):
+class StreamlitForm(StorageMixin, ContainerImageMixin, KeywordTagsValidationMixin, CreatorsMixin, AppBaseForm):
     flavor = forms.ModelChoiceField(queryset=Flavor.objects.none(), required=False, empty_label=None)
     port = forms.IntegerField(min_value=3000, max_value=9999, required=True)
     path = forms.CharField(max_length=255, required=False)
@@ -40,6 +41,19 @@ class StreamlitForm(StorageMixin, ContainerImageMixin, KeywordTagsValidationMixi
             "We allow keywords from MeSH, EuroSciVoc, and GEMET.",
             widget=forms.TextInput(attrs={"class": "form-control"}),
         )
+
+        self.fields["creators"] = forms.CharField(
+            required=False,
+            label="Creators",
+            help_text=(
+                "Manage the creators of this app. You are included as the primary creator by default. "
+                "You can add, edit, remove, and reorder creators as needed."
+            ),
+            widget=forms.HiddenInput(),  # Will be handled by custom template
+        )
+
+        # Initialize creators with current user if available
+        self._initialize_creators()
 
     def _setup_form_fields(self):
         # Handle Volume field

--- a/apps/forms/tissuumaps.py
+++ b/apps/forms/tissuumaps.py
@@ -6,13 +6,13 @@ from django.utils.safestring import mark_safe
 
 from apps.forms.base import AppBaseForm
 from apps.forms.field.common import SRVCommonDivField
-from apps.forms.mixins import KeywordTagsValidationMixin, VolumeMixin
+from apps.forms.mixins import CreatorsMixin, KeywordTagsValidationMixin, VolumeMixin
 from apps.models import TissuumapsInstance
 
 __all__ = ["TissuumapsForm"]
 
 
-class TissuumapsForm(VolumeMixin, KeywordTagsValidationMixin, AppBaseForm):
+class TissuumapsForm(VolumeMixin, KeywordTagsValidationMixin, CreatorsMixin, AppBaseForm):
     def _setup_form_fields(self):
         # Handle Volume field
         super()._setup_form_fields()
@@ -29,6 +29,19 @@ class TissuumapsForm(VolumeMixin, KeywordTagsValidationMixin, AppBaseForm):
             "We allow keywords from MeSH, EuroSciVoc, and GEMET.",
             widget=forms.TextInput(attrs={"class": "form-control"}),
         )
+
+        self.fields["creators"] = forms.CharField(
+            required=False,
+            label="Creators",
+            help_text=(
+                "Manage the creators of this app. You are included as the primary creator by default. "
+                "You can add, edit, remove, and reorder creators as needed."
+            ),
+            widget=forms.HiddenInput(),  # Will be handled by custom template
+        )
+
+        # Initialize creators with current user if available
+        self._initialize_creators()
 
     def _setup_form_helper(self):
         super()._setup_form_helper()

--- a/apps/tests/test_app_helper_utils.py
+++ b/apps/tests/test_app_helper_utils.py
@@ -205,9 +205,10 @@ class UpdateExistingAppInstanceTestCase(TestCase):
             "subdomain": self.subdomain_name,
             "language": "eng",
             "invenio_tags": "Antibodies|Cells",
+            "creators": '[{"name": "Test User", "email": "foo@test.com", "affiliation": "", "orcid": "", "order": 0}]',
         }
 
-        changed_fields = ["port", "invenio_tags", "tags"]
+        changed_fields = ["port", "invenio_tags", "tags", "creators"]
 
         # Apply the form and validate the result
         self._verify_update_instance_from_form(data, changed_fields)
@@ -236,9 +237,10 @@ class UpdateExistingAppInstanceTestCase(TestCase):
             "source_code_url": self.source_code_url,
             "subdomain": self.subdomain_name,
             "invenio_tags": "Antibodies|Cells",
+            "creators": '[{"name": "Test User", "email": "foo@test.com", "affiliation": "", "orcid": "", "order": 0}]',
         }
 
-        changed_fields = ["image", "invenio_tags", "tags"]
+        changed_fields = ["image", "invenio_tags", "tags", "creators"]
 
         # Apply the form and validate the result
         self._verify_update_instance_from_form(data, changed_fields)
@@ -268,9 +270,10 @@ class UpdateExistingAppInstanceTestCase(TestCase):
             "source_code_url": self.source_code_url,
             "subdomain": "test-subdomain-update-app-new",
             "invenio_tags": "Antibodies|Cells",
+            "creators": '[{"name": "Test User", "email": "foo@test.com", "affiliation": "", "orcid": "", "order": 0}]',
         }
 
-        changed_fields = ["subdomain", "invenio_tags", "tags"]
+        changed_fields = ["subdomain", "invenio_tags", "tags", "creators"]
 
         # Apply the form and validate the result
         self._verify_update_instance_from_form(data, changed_fields)
@@ -307,9 +310,10 @@ class UpdateExistingAppInstanceTestCase(TestCase):
             "source_code_url": "https://someurlthatdoesnotexist.com/new",
             "subdomain": self.subdomain_name,
             "invenio_tags": "Antibodies|Cells",
+            "creators": '[{"name": "Test User", "email": "foo@test.com", "affiliation": "", "orcid": "", "order": 0}]',
         }
 
-        changed_fields = ["name", "description", "source_code_url", "invenio_tags", "tags"]
+        changed_fields = ["name", "description", "source_code_url", "invenio_tags", "tags", "creators"]
 
         # Apply the form and validate the result
         self._verify_update_instance_from_form(data, changed_fields)

--- a/apps/views.py
+++ b/apps/views.py
@@ -322,7 +322,7 @@ class CreateApp(View):
             instance = None
 
         if user_can_edit or user_can_create:
-            return form_class(request.POST or None, project_pk=project.pk, instance=instance)
+            return form_class(request.POST or None, project_pk=project.pk, instance=instance, request=request)
             # Maybe this makes typing hard.
         else:
             return None


### PR DESCRIPTION
## Description

Jira: https://scilifelab.atlassian.net/browse/SS-1802

Backend changes to introduce a creator field in Serve app forms. To be used for DOI minting.

Changes are seen on the backend and in the logs as:

```Bash
2026-03-03 15:38:04 - DEBUG - apps.forms.mixins: Initialized creators with current user: [{'name': 'admin@serve.scilifelab.se', 'email': 'admin@serve.scilifelab.se', 'affiliation': '', 'orcid': '', 'order': 0}]
```

## Checklist

> If you're unsure about any of the items below, don't hesitate to ask. We're here to help!
> This is simply a reminder of what we are going to look for before merging your code.

- [ ] This pull request is against **develop** branch (not applicable for hotfixes)
- [X] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [ ] I have added or updated unit and end2end tests to complement my changes
- [ ] I have ran unit and end2end tests
- [ ] I have updated the related documentation (if necessary)
- [X] I have added a reviewer for this pull request
- [X] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts
- [ ] In case your changes are large enough, did you deploy your changes to develop instance?

# PR cheatsheet

- PR -- pull request
- Include jira ticket in the PR title (like `SS-1234 Introduced machine learning ai driven framework for DDLS Fellows from EMBL`)
- To set the status of the pull request, use the built-in github feature to set the PR as Draft or Ready for review.
- To indicate the type of change (such as bugfix or new feature), use a github pull request label.
- If pr is not ready for review, set it draft. We agreed in the team, that if the PR in the draft state, no one will review it.
- Remember, that you can trigger end2end tests manually
