### PR TITLE
Fix: disable funding test for Invenio and catch invenio_tag error

### DIFF
--- a/cypress/e2e/ui-tests/test-invenio-funding.cy.js
+++ b/cypress/e2e/ui-tests/test-invenio-funding.cy.js
@@ -1,5 +1,5 @@
 if (Cypress.env("create_resources") === true) {
-    describe("Test Invenio funding fields in app forms", () => {
+    describe.skip("Test Invenio funding fields in app forms", () => {
         let users;
         let TEST_USER_DATA;
         const TEST_PROJECT_DATA = {

--- a/templates/apps/create_base.html
+++ b/templates/apps/create_base.html
@@ -258,12 +258,12 @@ document.addEventListener("DOMContentLoaded", function() {
         updateUrlWithSubdomain();
     })
 
-    // Invenio Tags with Bootstrap Badges
+    // Invenio Tags with Bootstrap Badges (only if field exists)
     document.addEventListener('DOMContentLoaded', function() {
 
         const invenioTagsField = document.getElementById('id_invenio_tags');
         if (!invenioTagsField) {
-            console.error('[ERROR] invenio_tags field not found');
+            // Field not present - Invenio features disabled or not needed for this form, skip initialization
             return;
         }
 


### PR DESCRIPTION
## Description

Disable Invenio funding E2E test since the feature flag is OFF. Catch no invenio_tag error in apps that do not use tags.

## Checklist

> If you're unsure about any of the items below, don't hesitate to ask. We're here to help!
> This is simply a reminder of what we are going to look for before merging your code.

- [X] This pull request is against **develop** branch (not applicable for hotfixes)
- [ ] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [ ] I have added or updated unit and end2end tests to complement my changes
- [x] I have ran unit and end2end tests
- [ ] I have updated the related documentation (if necessary)
- [ ] I have added a reviewer for this pull request
- [X] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts
- [ ] In case your changes are large enough, did you deploy your changes to develop instance?

# PR cheatsheet

- PR -- pull request
- Include jira ticket in the PR title (like `SS-1234 Introduced machine learning ai driven framework for DDLS Fellows from EMBL`)
- To set the status of the pull request, use the built-in github feature to set the PR as Draft or Ready for review.
- To indicate the type of change (such as bugfix or new feature), use a github pull request label.
- If pr is not ready for review, set it draft. We agreed in the team, that if the PR in the draft state, no one will review it.
- Remember, that you can trigger end2end tests manually
