### PR TITLE
Fix AttributeError in affiliation processing for legacy data

### DIFF
--- a/api/openapi/content_stats_api.py
+++ b/api/openapi/content_stats_api.py
@@ -112,7 +112,7 @@ class ContentStatsAPI(viewsets.ReadOnlyModelViewSet):
                     if isinstance(aff, dict):
                         title = aff.get("title", "").strip()
                     else:
-                        title = "Unknown (legacy value)"
+                        title = f"Unknown (legacy value, type: {type(aff).__name__})"
                     if title:
                         univ_list.append(title)
             users_by_univ = dict(Counter(univ_list))

--- a/api/openapi/content_stats_api.py
+++ b/api/openapi/content_stats_api.py
@@ -109,7 +109,10 @@ class ContentStatsAPI(viewsets.ReadOnlyModelViewSet):
             for profile in user_profiles:
                 affs = profile.get_affiliations()
                 for aff in affs:
-                    title = aff.get("title", "").strip()
+                    if isinstance(aff, dict):
+                        title = aff.get("title", "").strip()
+                    else:
+                        title = "Unknown (legacy value)"
                     if title:
                         univ_list.append(title)
             users_by_univ = dict(Counter(univ_list))

--- a/common/admin.py
+++ b/common/admin.py
@@ -139,7 +139,9 @@ class UserAdmin(DefaultUserAdmin):
                     titles.append(f"Unknown (legacy value, type: {type(aff).__name__})")
             return " | ".join(titles) if titles else "N/A"
         except UserProfile.DoesNotExist:
-            return "N/A"
+            return "N/A (no profile)"
+        except Exception as e:
+            return f"N/A (error: {e})"
 
     @admin.display(description="ORCID iD")
     def get_orcid(self, instance):

--- a/common/admin.py
+++ b/common/admin.py
@@ -136,7 +136,7 @@ class UserAdmin(DefaultUserAdmin):
                 if isinstance(aff, dict):
                     titles.append(aff.get("title", "Unknown"))
                 else:
-                    titles.append("Unknown (legacy value)")
+                    titles.append(f"Unknown (legacy value, type: {type(aff).__name__})")
             return " | ".join(titles) if titles else "N/A"
         except UserProfile.DoesNotExist:
             return "N/A"

--- a/common/admin.py
+++ b/common/admin.py
@@ -131,7 +131,13 @@ class UserAdmin(DefaultUserAdmin):
             affs = instance.userprofile.get_affiliations()
             if not affs:
                 return "N/A"
-            return " | ".join(aff.get("title", "Unknown") for aff in affs)
+            titles = []
+            for aff in affs:
+                if isinstance(aff, dict):
+                    titles.append(aff.get("title", "Unknown"))
+                else:
+                    titles.append("Unknown (legacy value)")
+            return " | ".join(titles) if titles else "N/A"
         except UserProfile.DoesNotExist:
             return "N/A"
 


### PR DESCRIPTION
## Description

**Fix AttributeError in affiliation processing for legacy data**

Some user profiles contain legacy plain-string values in their `affiliations` JSON field instead of the expected `{"title": "...", "ror_id": "..."}` dict format. This was caused by data written outside the migration path during a separate load test, bypassing the migration logic that normalizes affiliations into dicts. This causes an `AttributeError: 'str' object has no attribute 'get'` when iterating affiliations in both the admin display (`admin.py`) and the content stats API (`content_stats_api.py`).

This fix adds an `isinstance(aff, dict)` guard in both locations. Non-dict entries are labeled `"Unknown (legacy value)"` to make them visible for future data cleanup.

**Note:** After deploying, make sure the affiliation data migration has run successfully and check the container stdout logs for the migration summary, specifically that `failed_count` is 0 and the `migrated` count matches expectations. Also check the application logs for any `"Unknown (legacy value)"` entries, which indicate profiles still holding non-dict data that should be normalized to the new format.

## Checklist

> If you're unsure about any of the items below, don't hesitate to ask. We're here to help!
> This is simply a reminder of what we are going to look for before merging your code.

- [x] This pull request is against **develop** branch (not applicable for hotfixes)
- [ ] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [ ] I have added or updated unit and end2end tests to complement my changes
- [ ] I have ran unit and end2end tests
- [ ] I have updated the related documentation (if necessary)
- [x] I have added a reviewer for this pull request
- [x] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts
- [ ] In case your changes are large enough, did you deploy your changes to develop instance?

# PR cheatsheet

- PR -- pull request
- Include jira ticket in the PR title (like `SS-1234 Introduced machine learning ai driven framework for DDLS Fellows from EMBL`)
- To set the status of the pull request, use the built-in github feature to set the PR as Draft or Ready for review.
- To indicate the type of change (such as bugfix or new feature), use a github pull request label.
- If pr is not ready for review, set it draft. We agreed in the team, that if the PR in the draft state, no one will review it.
- Remember, that you can trigger end2end tests manually
