### PR TITLE
fix openapi content stats url

### DIFF
--- a/portal/views.py
+++ b/portal/views.py
@@ -41,7 +41,7 @@ def __get_content_stats(request) -> dict[str, Any]:
     """
 
     host = request.build_absolute_uri("/")
-    api_url = host + reverse("v1:openapi-content-stats")
+    api_url = host.rstrip("/") + reverse("v1:openapi-content-stats")
 
     response = requests.get(api_url)
 

--- a/portal/views.py
+++ b/portal/views.py
@@ -1,4 +1,5 @@
-from typing import Any, cast
+from pathlib import Path
+from typing import Any
 
 import markdown
 import requests
@@ -14,7 +15,7 @@ from django.urls import reverse
 from django.utils import timezone
 from django.utils.text import slugify
 from django.views.generic import View
-from requests.exceptions import RequestException, Timeout
+from requests.exceptions import RequestException
 
 from apps.app_registry import APP_REGISTRY
 from apps.models import Apps, BaseAppInstance, SocialMixin
@@ -35,20 +36,19 @@ Collection = apps.get_model(app_label="portal.Collection")
 # 2. add type annotations
 
 
-def __get_content_stats(request) -> dict[str, Any]:
-    """
-    Gets content statistics via internal API call.
-    """
+def __get_university_logo_names() -> list[str]:
+    logo_dir = Path(settings.BASE_DIR) / "static" / "images" / "logos" / "universities"
+    if not logo_dir.exists():
+        return []
+    return sorted(path.stem for path in logo_dir.glob("*.png"))
 
-    host = request.build_absolute_uri("/")
-    api_url = host.rstrip("/") + reverse("v1:openapi-content-stats")
 
-    response = requests.get(api_url)
-
-    if response.status_code == 200:
-        return cast(dict[str, Any], response.json()["data"])
-    else:
-        raise Exception("Content Stats API did not return status 200")
+def __get_content_stats() -> dict[str, int]:
+    apps = BaseAppInstance.objects.get_app_instances_not_deleted().filter(app__category__slug="serve")
+    return {
+        "n_apps": apps.count(),
+        "n_apps_public": apps.filter(k8s_values__permission="public").count(),
+    }
 
 
 def get_public_apps(request, app_id=0, collection=None, order_by="updated_on", order_reverse=False):
@@ -90,10 +90,6 @@ def add_additional_context_to_public_apps(published_apps):
     serialized_apps = []
     organizations, departments, tags = set(), set(), set()
 
-    universities_lookup = requests.get(settings.STUDIO_URL + "/openapi/v1/lookups/universities")
-    universities = universities_lookup.json().get("data")
-    universities_obj = {u["code"]: u["name"] for u in universities}
-
     for app in published_apps:
         try:
             affs = app.owner.userprofile.get_affiliations()
@@ -119,7 +115,6 @@ def add_additional_context_to_public_apps(published_apps):
             affiliation = ""
             dep_cleaned = ""
 
-        print(f"Processing app: {app.name} ({app.id})")
         tag_list = app.tags.get_tag_list()
         tags.update(tag_list)
         k8s_values = getattr(app, "k8s_values", {})
@@ -157,7 +152,12 @@ def add_additional_context_to_public_apps(published_apps):
             }
         )
 
-    unique_organizations = list(organizations)
+    if organizations:
+        unique_organizations = sorted(organizations)
+    else:
+        universities_lookup = requests.get(settings.STUDIO_URL + "/openapi/v1/lookups/universities")
+        universities = universities_lookup.json().get("data", [])
+        unique_organizations = sorted(u["name"] for u in universities if u.get("name"))
     unique_departments = list(departments)
     unique_tags = list(tags)
     return serialized_apps, unique_organizations, unique_departments, unique_tags
@@ -181,18 +181,15 @@ def public_apps(request, app_id=0):
         serialized_apps, unique_organizations, unique_departments, unique_tags = add_additional_context_to_public_apps(
             published_apps
         )
+        university_logo_names = __get_university_logo_names()
         try:
             total_count = None
             public_count = None
-            n_users = None
-            n_projects = None
             stats_error = None
-            stats = __get_content_stats(request)  # make sure this uses a timeout (see below)
+            stats = __get_content_stats()
             total_count = stats.get("n_apps", total_count)
             public_count = stats.get("n_apps_public", public_count)
-            n_users = stats.get("n_users", n_users)
-            n_projects = stats.get("n_projects", n_projects)
-        except (Timeout, RequestException, ValueError, KeyError) as e:
+        except (RequestException, ValueError, KeyError) as e:
             stats_error = str(e)
             logger.warning("Content stats API failed: %s", e, exc_info=True)
     except Exception as e:

--- a/templates/portal/apps.html
+++ b/templates/portal/apps.html
@@ -186,8 +186,12 @@
                                 <a class="tag tag-filter card-institution me-1 mb-2 {% if forloop.counter > 15 %}filter-collapsed{% endif %}"
                                    onclick="searchByTag('{{ org }}','card-institution',this)">
     <span class="badge text-bg-primary badge-grape badge-ico-text-filter">
+    {% if org in university_logo_names %}
     <img class="filter-tag-org-icon me-1" src="{{ university_logo_static_url }}{{ org }}.png" alt="{{ org }} logo" loading="lazy" onerror="this.classList.add('d-none'); this.nextElementSibling.classList.remove('d-none'); this.nextElementSibling.classList.add('org-fallback-icon'); this.closest('.badge').classList.add('org-fallback-badge');">
     <i class="fas fa-graduation-cap me-1 filter-tag-icon-org d-none" aria-hidden="true"></i>
+    {% else %}
+    <i class="fas fa-graduation-cap me-1 filter-tag-icon-org org-fallback-icon" aria-hidden="true"></i>
+    {% endif %}
     <span class="tag-name">{{ org }}</span>
     </span>
                                 </a>
@@ -436,8 +440,12 @@
                         <a class="tag tag-filter card-institution me-1 mb-2 {% if forloop.counter > 15 %}filter-collapsed{% endif %}"
                            onclick="searchByTag('{{ org }}','card-institution',this)">
 <span class="badge text-bg-primary badge-grape badge-ico-text-filter">
+{% if org in university_logo_names %}
 <img class="filter-tag-org-icon me-1" src="{{ university_logo_static_url }}{{ org }}.png" alt="{{ org }} logo" loading="lazy" onerror="this.classList.add('d-none'); this.nextElementSibling.classList.remove('d-none'); this.nextElementSibling.classList.add('org-fallback-icon'); this.closest('.badge').classList.add('org-fallback-badge');">
 <i class="fas fa-graduation-cap me-1 filter-tag-icon-org d-none" aria-hidden="true"></i>
+{% else %}
+<i class="fas fa-graduation-cap me-1 filter-tag-icon-org org-fallback-icon" aria-hidden="true"></i>
+{% endif %}
 <span class="tag-name">{{ org }}</span>
 </span>
                         </a>


### PR DESCRIPTION
## Description

 __get_content_stats() in portal/views.py constructs the API URL by concatenating request.build_absolute_uri("/") and reverse("v1:openapi-content-stats"), producing a double-slash URL.

serve-dev's request goes HTTP→HTTPS via a 308 redirect, which normalizes the path. Staging hits HTTPS directly, no redirect, no normalization; so the double slash reaches Django's URL resolver and returns 404.

Will work, serve-dev:

https://serve-dev.scilifelab.se//openapi/v1/content-stats

Won't work, serve-staging:

https://serve-staging.serve-dev.scilifelab.se//openapi/v1/content-stats

## Checklist

> If you're unsure about any of the items below, don't hesitate to ask. We're here to help!
> This is simply a reminder of what we are going to look for before merging your code.

- [ ] This pull request is against **develop** branch (not applicable for hotfixes)
- [ ] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [ ] I have added or updated unit and end2end tests to complement my changes
- [ ] I have ran unit and end2end tests
- [ ] I have updated the related documentation (if necessary)
- [ ] I have added a reviewer for this pull request
- [ ] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts
- [ ] In case your changes are large enough, did you deploy your changes to develop instance?

# PR cheatsheet

- PR -- pull request
- Include jira ticket in the PR title (like `SS-1234 Introduced machine learning ai driven framework for DDLS Fellows from EMBL`)
- To set the status of the pull request, use the built-in github feature to set the PR as Draft or Ready for review.
- To indicate the type of change (such as bugfix or new feature), use a github pull request label.
- If pr is not ready for review, set it draft. We agreed in the team, that if the PR in the draft state, no one will review it.
- Remember, that you can trigger end2end tests manually
