### PR TITLE
SS-1809 enable background tasks for multiple app types

### DIFF
--- a/apps/background_tasks/tasks/doi_provisioning.py
+++ b/apps/background_tasks/tasks/doi_provisioning.py
@@ -71,7 +71,7 @@ def _build_additional_metadata(
     name="doi_provisioning",
     is_critical=False,
     execution_order=2,
-    app_types=["customapp"],
+    app_types=["customapp", "shinyproxyapp", "shinyapp", "gradio", "streamlit", "tissuumaps", "depictio"],
 )
 class DOIProvisioningTask(BaseBackgroundTask):
     """

--- a/apps/background_tasks/tasks/validation.py
+++ b/apps/background_tasks/tasks/validation.py
@@ -15,7 +15,10 @@ logger = get_logger(__name__)
 
 
 @TASK_REGISTRY.register(
-    name="validate_docker_image", is_critical=True, execution_order=1, app_types=["customapp", "jupyter", "rstudio"]
+    name="validate_docker_image",
+    is_critical=True,
+    execution_order=1,
+    app_types=["customapp", "dashapp", "jupyter-lab", "rstudio", "shinyproxyapp", "shinyapp", "gradio", "streamlit"],
 )
 class DockerImageValidator(BaseBackgroundTask):
     """

--- a/apps/tests/test_background_tasks_framework.py
+++ b/apps/tests/test_background_tasks_framework.py
@@ -29,6 +29,29 @@ def test_known_tasks_are_registered_after_django_startup():
 
 
 @pytest.mark.django_db
+def test_known_tasks_apply_to_non_custom_app_types():
+    streamlit_tasks = TASK_REGISTRY.get_tasks_for_app("streamlit")
+
+    assert "validate_docker_image" in [task.task_name for task in streamlit_tasks]
+    assert "doi_provisioning" in [task.task_name for task in streamlit_tasks]
+
+
+@pytest.mark.django_db
+def test_doi_provisioning_is_not_registered_for_jupyter_lab():
+    jupyter_tasks = TASK_REGISTRY.get_tasks_for_app("jupyter-lab")
+
+    assert "validate_docker_image" in [task.task_name for task in jupyter_tasks]
+    assert "doi_provisioning" not in [task.task_name for task in jupyter_tasks]
+
+
+@pytest.mark.django_db
+def test_validate_docker_image_is_not_registered_for_non_image_apps():
+    tissuumaps_tasks = TASK_REGISTRY.get_tasks_for_app("tissuumaps")
+
+    assert "validate_docker_image" not in [task.task_name for task in tissuumaps_tasks]
+
+
+@pytest.mark.django_db
 def test_doi_provisioning_task_includes_funding_metadata(app_instance):
     funding_payload = [
         {
@@ -381,5 +404,61 @@ def test_run_background_tasks_creates_db_rows_and_schedules_workflow(
     rows = BackgroundTask.objects.filter(app_instance=app_instance).order_by("execution_order")
     assert rows.count() == 2
     assert [r.task_name for r in rows] == ["unit_one", "unit_two"]
+    assert all(r.status == "pending" for r in rows)
+    assert called["apply_async"] == 1
+
+
+@pytest.mark.django_db
+def test_run_background_tasks_uses_known_tasks_for_streamlit(immediate_on_commit, monkeypatch):
+    user = User.objects.create_user("u_streamlit", "u_streamlit@test.com", "pw")
+    project = Project.objects.create_project(name="p_streamlit", owner=user, description="")
+    app = Apps.objects.create(name="Streamlit App", slug="streamlit")
+    app_instance = BaseAppInstance.objects.create(owner=user, project=project, app=app, chart="test-chart")
+
+    called = {"apply_async": 0}
+
+    class FakeWorkflow:
+        def apply_async(self):
+            called["apply_async"] += 1
+
+    import celery  # type: ignore
+
+    monkeypatch.setattr(celery, "chain", lambda *steps: FakeWorkflow())
+    monkeypatch.setattr(celery, "group", lambda steps: types.SimpleNamespace(steps=steps))
+
+    result = run_background_tasks(serialized_instance=app_instance.serialize(), app_slug="streamlit")
+
+    assert result["success"] is True
+
+    rows = BackgroundTask.objects.filter(app_instance=app_instance).order_by("execution_order", "task_name")
+    assert [r.task_name for r in rows] == ["validate_docker_image", "doi_provisioning"]
+    assert all(r.status == "pending" for r in rows)
+    assert called["apply_async"] == 1
+
+
+@pytest.mark.django_db
+def test_run_background_tasks_uses_only_validation_for_jupyter_lab(immediate_on_commit, monkeypatch):
+    user = User.objects.create_user("u_jupyter_run", "u_jupyter_run@test.com", "pw")
+    project = Project.objects.create_project(name="p_jupyter_run", owner=user, description="")
+    app = Apps.objects.create(name="JupyterLab", slug="jupyter-lab")
+    app_instance = BaseAppInstance.objects.create(owner=user, project=project, app=app, chart="test-chart")
+
+    called = {"apply_async": 0}
+
+    class FakeWorkflow:
+        def apply_async(self):
+            called["apply_async"] += 1
+
+    import celery  # type: ignore
+
+    monkeypatch.setattr(celery, "chain", lambda *steps: FakeWorkflow())
+    monkeypatch.setattr(celery, "group", lambda steps: types.SimpleNamespace(steps=steps))
+
+    result = run_background_tasks(serialized_instance=app_instance.serialize(), app_slug="jupyter-lab")
+
+    assert result["success"] is True
+
+    rows = BackgroundTask.objects.filter(app_instance=app_instance).order_by("execution_order", "task_name")
+    assert [r.task_name for r in rows] == ["validate_docker_image"]
     assert all(r.status == "pending" for r in rows)
     assert called["apply_async"] == 1

--- a/static/css/serve-elements.css
+++ b/static/css/serve-elements.css
@@ -101,6 +101,10 @@
     opacity: 0.5;
 }
 
+.serve-admin-dropdown-trigger {
+    padding-bottom: 10px;
+}
+
 /* forms */
 
 .form-control {

--- a/templates/apps/create_base.html
+++ b/templates/apps/create_base.html
@@ -1,6 +1,5 @@
 {% extends 'base.html' %}
 {% block title %}{{ form_header }} {{ app.name }}{% endblock %}
-{% load static %}
 {% load custom_tags %}
 {% load crispy_forms_tags %}
 
@@ -13,14 +12,48 @@
         <div class="w-100 card shadow border-1">
             <div class="card-body">
             {% if app_id %}
-              <h1 class="h3 mb-3 card-title">Edit {{ form.instance.name }}
+              <div class="d-flex align-items-center justify-content-between gap-2 mb-3">
+                <h1 class="h3 mb-0 card-title">Edit {{ form.instance.name }}</h1>
                 {% if user.is_authenticated and user.is_staff %}
-                  <a href="{% url 'admin:apps_'|add:model_name|add:'_change' app_id %}" class="btn btn-primary ms-2"
-                     data-cy="admin-app" target="_blank">
-                    🐳 Admin view
-                  </a>
+                  <div class="dropdown">
+                    <a
+                      href="#"
+                      class="btn btn-primary serve-admin-dropdown-trigger"
+                      role="button"
+                      id="appAdminMenu"
+                      data-bs-toggle="dropdown"
+                      aria-expanded="false"
+                      data-cy="admin-app-menu"
+                    >
+                      <span class="me-1" aria-hidden="true">🐳</span>
+                      <span>Admin View</span>
+                      <i class="bi bi-caret-down-fill small ms-2" aria-hidden="true"></i>
+                    </a>
+                    <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="appAdminMenu">
+                      <li>
+                        <a
+                          class="dropdown-item"
+                          href="{% url 'admin:apps_'|add:model_name|add:'_change' app_id %}"
+                          data-cy="admin-app"
+                          target="_blank"
+                        >
+                          App admin page
+                        </a>
+                      </li>
+                      <li>
+                        <a
+                          class="dropdown-item"
+                          href="{% url 'apps:background_tasks' project.slug app_slug app_id %}"
+                          data-cy="app-background-tasks"
+                          target="_blank"
+                        >
+                          Background tasks
+                        </a>
+                      </li>
+                    </ul>
+                  </div>
                 {% endif %}
-              </h1>
+              </div>
             {% else %}
                 <h1 class="h3 mb-3 card-title">Create {{ form.model_name }}</h1>
             {% endif %}

--- a/templates/projects/partials/project_header.html
+++ b/templates/projects/partials/project_header.html
@@ -19,10 +19,43 @@
       Settings
     </a>
     {% if user.is_authenticated and user.is_staff %}
-      <a href="{% url 'admin:projects_project_change' project.id %}" class="btn btn-primary ms-2"
-         data-cy="admin-project" target="_blank">
-        🐳 Admin view
-      </a>
+      <div class="dropdown ms-2">
+        <a
+          href="#"
+          class="btn btn-primary serve-admin-dropdown-trigger"
+          role="button"
+          id="projectAdminMenu"
+          data-bs-toggle="dropdown"
+          aria-expanded="false"
+          data-cy="admin-project-menu"
+        >
+          <span class="me-1" aria-hidden="true">🐳</span>
+          <span>Admin View</span>
+          <i class="bi bi-caret-down-fill small ms-2" aria-hidden="true"></i>
+        </a>
+        <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="projectAdminMenu">
+          <li>
+            <a
+              class="dropdown-item"
+              href="{% url 'admin:projects_project_change' project.id %}"
+              data-cy="admin-project"
+              target="_blank"
+            >
+              Project admin page
+            </a>
+          </li>
+          <li>
+            <a
+              class="dropdown-item"
+              href="{% url 'apps:admin_background_tasks' project.slug %}"
+              data-cy="admin-background-tasks"
+              target="_blank"
+            >
+              Background tasks
+            </a>
+          </li>
+        </ul>
+      </div>
     {% endif %}
   </div>
 </div>


### PR DESCRIPTION
## Description

Extends the background-task allow lists so they match the intended app behavior for [SS-1809](https://scilifelab.atlassian.net/browse/SS-1809).

Changes included in this PR:
- `doi_provisioning` now uses an extended app-type allow list and runs for:
  `customapp`, `shinyproxyapp`, `shinyapp`, `gradio`, `streamlit`, `tissuumaps`, `depictio`
- `validate_docker_image` now runs only for app types that actually take an image:
  `customapp`, `dashapp`, `jupyter-lab`, `rstudio`, `shinyproxyapp`, `shinyapp`, `gradio`, `streamlit`
- Added/updated unit tests to verify:
  - DOI minting is not registered for `jupyter-lab`
  - image validation is not registered for non-image apps such as `tissuumaps`
  - supported app types still go through the expected background-task flow

## Checklist

- [x] This pull request is against **develop** branch (not applicable for hotfixes)
- [x] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [x] I have added or updated unit and end2end tests or a manual test case to complement my changes
- [x] I have ran unit and end2end tests
- [ ] I have updated the related documentation (if necessary)
- [x] I have added a reviewer for this pull request
- [x] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts
- [ ] In case your changes are large enough, did you deploy your changes to develop instance?