### PR TITLE
SS-1904 remove background tasks UI for dev apps

### DIFF
--- a/apps/models/base/app_template.py
+++ b/apps/models/base/app_template.py
@@ -1,5 +1,9 @@
 from django.db import models
 
+# Categories where users are taken to project page
+# instead of deployment-details page.
+CATEGORY_SLUGS_WITHOUT_DEPLOYMENT_DETAILS = {"develop", "manage-files"}
+
 
 class Apps(models.Model):
     """Essentially app template"""
@@ -40,6 +44,12 @@ class Apps(models.Model):
 
     def __str__(self):
         return str(self.name) + "({})".format(self.revision)
+
+    @property
+    def should_display_deployment_details(self):
+        # `category_id` is the slug string — AppCategories uses `slug` as PK.
+        category_slug = self.category_id or ""
+        return category_slug not in CATEGORY_SLUGS_WITHOUT_DEPLOYMENT_DETAILS
 
     def to_dict(self):
         pass

--- a/apps/tests/test_create_app_view.py
+++ b/apps/tests/test_create_app_view.py
@@ -306,13 +306,17 @@ class CreateAppViewTestCase(TestCase):
 
         fake_form = Mock()
         fake_form.is_valid.return_value = True
+        fake_form.instance.app.should_display_deployment_details = True
 
-        with patch("apps.views.CreateApp.get_form", return_value=fake_form), patch(
-            "apps.views.create_instance_from_form",
-            return_value=CreateInstanceResult(
-                instance_id=321,
-                progress_started_at="2026-04-17T10:11:12+00:00",
-                workflow_started=True,
+        with (
+            patch("apps.views.CreateApp.get_form", return_value=fake_form),
+            patch(
+                "apps.views.create_instance_from_form",
+                return_value=CreateInstanceResult(
+                    instance_id=321,
+                    progress_started_at="2026-04-17T10:11:12+00:00",
+                    workflow_started=True,
+                ),
             ),
         ):
             response = c.post(
@@ -326,3 +330,23 @@ class CreateAppViewTestCase(TestCase):
             f"{project.slug}/apps/progress/jupyter-lab/321?"
             f"{urlencode({'started_at': '2026-04-17T10:11:12+00:00'})}",
         )
+
+        fake_form = Mock()
+        fake_form.is_valid.return_value = True
+        fake_form.instance.app.should_display_deployment_details = False
+
+        with (
+            patch("apps.views.CreateApp.get_form", return_value=fake_form),
+            patch(
+                "apps.views.create_instance_from_form",
+                return_value=CreateInstanceResult(
+                    instance_id=321,
+                    progress_started_at="2026-04-17T10:11:12+00:00",
+                    workflow_started=True,
+                ),
+            ),
+        ):
+            response = c.post(f"/projects/{project.slug}/apps/create/jupyter-lab")
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, f"/projects/{project.slug}/")

--- a/apps/views.py
+++ b/apps/views.py
@@ -65,6 +65,14 @@ logger = get_logger(__name__)
 User = get_user_model()
 
 
+def _should_restrict_deployment_details(request, instance):
+    return (
+        not instance.app.should_display_deployment_details
+        and not request.user.is_staff
+        and not request.user.is_superuser
+    )
+
+
 @method_decorator(
     permission_required_or_403("can_view_project", (Project, "slug", "project")),
     name="dispatch",
@@ -341,6 +349,11 @@ class CreateApp(View):
 
         # Otherwise we can create the instance
         result = create_instance_from_form(form, project, app_slug, app_id)
+        # Redirects everyone (including admins) after creation; admins can still
+        # open the deployment pages (/progress, /details, /tasks) directly.
+        if not form.instance.app.should_display_deployment_details:
+            return HttpResponseRedirect(reverse("projects:details", kwargs={"project_slug": project_slug}))
+
         if not result.workflow_started:
             return HttpResponseRedirect(
                 build_project_app_path(str(project_slug), f"details/{app_slug}/{result.instance_id}")
@@ -412,6 +425,9 @@ class DeploymentProgressView(View):
 
     def get(self, request, project, app_slug, app_id):
         project_obj, instance = get_project_app_instance(project, app_slug, app_id)
+        if _should_restrict_deployment_details(request, instance):
+            return HttpResponseRedirect(reverse("projects:details", kwargs={"project_slug": project_obj.slug}))
+
         progress_mode = get_progress_mode_from_request(request) or "deploy"
         progress_started_at = get_progress_started_at_from_request(request)
         skip_deploy = get_skip_deploy_from_request(request)
@@ -451,6 +467,9 @@ class AppDetailsView(View):
 
     def get(self, request, project, app_slug, app_id):
         project_obj, instance = get_project_app_instance(project, app_slug, app_id)
+        if _should_restrict_deployment_details(request, instance):
+            return HttpResponseRedirect(reverse("projects:details", kwargs={"project_slug": project_obj.slug}))
+
         progress_state = build_progress_state(instance, progress_mode="details")
         tasks_data = progress_state["tasks"]
 
@@ -766,6 +785,9 @@ class BackgroundTasksView(View):
 
     def get(self, request, project, app_slug, app_id):
         project_obj, instance = get_project_app_instance(project, app_slug, app_id)
+        if _should_restrict_deployment_details(request, instance):
+            return HttpResponseRedirect(reverse("projects:details", kwargs={"project_slug": project_obj.slug}))
+
         tasks = get_progress_tasks(instance)
         serialized_tasks = serialize_tasks(tasks)
         serialized_by_id = {task_data["id"]: task_data for task_data in serialized_tasks}
@@ -806,6 +828,9 @@ class BackgroundTaskStatusAPI(View):
             _, instance = get_project_app_instance(project, app_slug, app_id)
         except (Http404, PermissionDenied):
             return JsonResponse({"error": "App instance not found"}, status=404)
+        if _should_restrict_deployment_details(request, instance):
+            return JsonResponse({"error": "Deployment details are available to administrators only."}, status=403)
+
         progress_mode = get_progress_mode_from_request(request) or "deploy"
         progress_started_at = get_progress_started_at_from_request(request)
         skip_deploy = get_skip_deploy_from_request(request)
@@ -846,6 +871,8 @@ class RetryBackgroundTaskView(View):
             instance = model_class.objects.get(pk=app_id)
         except model_class.DoesNotExist:
             return JsonResponse({"error": "App instance not found"}, status=404)
+        if _should_restrict_deployment_details(request, instance):
+            raise PermissionDenied("Deployment details are available to administrators only.")
 
         # Get the task
         try:

--- a/templates/projects/partials/app_instances_table.html
+++ b/templates/projects/partials/app_instances_table.html
@@ -97,11 +97,13 @@
                         <i class="ellipsis vertical icon"></i>
                     </a>
                     <div class="dropdown-menu dropdown-menu-end">
+                        {% if instance.app.should_display_deployment_details or user.is_staff or user.is_superuser %}
                         <a class="dropdown-item default"
                             href="{% url 'apps:details' project.slug instance.app.slug instance.pk %}">
                             <i class="bi bi-info-circle me-1"></i>
                             Details
                         </a>
+                        {% endif %}
                         {% if objs.title == "Serve" %}
                         <a class="dropdown-item default"
                             href="{% url 'apps:logs' project.slug instance.app.slug instance.pk %}?from=overview">


### PR DESCRIPTION
## Description

This PR relates to [SS-1904](https://scilifelab.atlassian.net/browse/SS-1904).

Develop and Manage files app categories now return users to the project dashboard instead of showing the deployment progress/details flow. Admin users can still open the deployment details and background task pages (via the details link in the settings) if they need to.

- Adds an app-template property for deciding whether deployment details should be shown.
- Redirects post-create/update flows for Develop and Manage files apps back to the project dashboard.
- Restricts direct details/background-task pages for regular users, with admin access still possible.
- Hides the project dashboard “Details” action for regular users on apps that should not expose deployment details.
- Extends the existing create-app view test to cover the dashboard redirect case.

## Checklist

> If you're unsure about any of the items below, don't hesitate to ask. We're here to help!
> This is simply a reminder of what we are going to look for before merging your code.

- [x] This pull request is against **develop** branch (not applicable for hotfixes)
- [x] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [x] I have added or updated unit and end2end tests or a manual test case to complement my changes
- [ ] I have ran unit and end2end tests
- [ ] I have updated the related documentation (if necessary)
- [x] I have added a reviewer for this pull request
- [x] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts
- [ ] In case your changes are large enough, did you deploy your changes to develop instance?

# PR cheatsheet

- PR -- pull request
- Include jira ticket in the PR title (like `SS-1234 Introduced machine learning ai driven framework for DDLS Fellows from EMBL`)
- To set the status of the pull request, use the built-in github feature to set the PR as Draft or Ready for review.
- To indicate the type of change (such as bugfix or new feature), use a github pull request label.
- If pr is not ready for review, set it draft. We agreed in the team, that if the PR in the draft state, no one will review it.
- Remember, that you can trigger end2end tests manually
