### PR TITLE
ss-1935 Use Renovate to detect new app chart versions in serve-charts

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "matchPackageNames": ["*"],
+      "enabled": false
+    },
+    {
+      "matchPackagePatterns": ["^ghcr\\.io/scilifelabdatacentre/serve-charts/"],
+      "enabled": true,
+      "groupName": "serve-charts app versions",
+      "additionalBranchPrefix": "renovate-",
+      "commitMessageTopic": "Update serve-charts {{depName}} to {{newValue}}",
+      "automerge": false,
+      "schedule": ["* 8-17 * * 1-5"],
+      "prConcurrentLimit": 1
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^fixtures/apps_fixtures\\.json$"],
+      "matchStrings": [
+        "\"chart\":\\s*\"(?<depName>ghcr\\.io/scilifelabdatacentre/serve-charts/[^:]+):(?<currentValue>[^\"]+)\""
+      ],
+      "datasourceTemplate": "docker"
+    }
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "timezone": "Europe/Stockholm",
   "customManagers": [
     {
       "customType": "regex",
@@ -31,5 +30,6 @@
       ],
       "prConcurrentLimit": 1
     }
-  ]
+  ],
+  "timezone": "Europe/Stockholm"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,29 +1,37 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "packageRules": [
-    {
-      "matchPackageNames": ["*"],
-      "enabled": false
-    },
-    {
-      "matchPackagePatterns": ["^ghcr\\.io/scilifelabdatacentre/serve-charts/"],
-      "enabled": true,
-      "groupName": "serve-charts app versions",
-      "additionalBranchPrefix": "renovate-",
-      "commitMessageTopic": "Update serve-charts {{depName}} to {{newValue}}",
-      "automerge": false,
-      "schedule": ["* 8-17 * * 1-5"],
-      "prConcurrentLimit": 1
-    }
-  ],
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["^fixtures/apps_fixtures\\.json$"],
+      "datasourceTemplate": "docker",
+      "fileMatch": [
+        "^fixtures/apps_fixtures\\.json$"
+      ],
       "matchStrings": [
         "\"chart\":\\s*\"(?<depName>ghcr\\.io/scilifelabdatacentre/serve-charts/[^:]+):(?<currentValue>[^\"]+)\""
+      ]
+    }
+  ],
+  "packageRules": [
+    {
+      "enabled": false,
+      "matchPackageNames": [
+        "*"
+      ]
+    },
+    {
+      "additionalBranchPrefix": "renovate-",
+      "automerge": false,
+      "commitMessageTopic": "Update serve-charts {{depName}} to {{newValue}}",
+      "enabled": true,
+      "groupName": "serve-charts app versions",
+      "matchPackagePatterns": [
+        "^ghcr\\.io/scilifelabdatacentre/serve-charts/"
       ],
-      "datasourceTemplate": "docker"
+      "prConcurrentLimit": 1,
+      "schedule": [
+        "* 8-17 * * 1-5"
+      ]
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "timezone": "Europe/Stockholm",
   "customManagers": [
     {
       "customType": "regex",
@@ -22,16 +23,13 @@
     {
       "additionalBranchPrefix": "renovate-",
       "automerge": false,
-      "commitMessageTopic": "Update serve-charts {{depName}} to {{newValue}}",
+      "commitMessageTopic": "serve-charts {{depName}}",
       "enabled": true,
       "groupName": "serve-charts app versions",
       "matchPackagePatterns": [
         "^ghcr\\.io/scilifelabdatacentre/serve-charts/"
       ],
-      "prConcurrentLimit": 1,
-      "schedule": [
-        "* 8-17 * * 1-5"
-      ]
+      "prConcurrentLimit": 1
     }
   ]
 }


### PR DESCRIPTION
## Description

Jira: https://scilifelab.atlassian.net/browse/SS-1935

An attempt to replace the custom GitHub Actions workflow that checks for latest app chart versions in serve-charts and updates `serve/fixtures/apps_fixtures.json`.

- [x] If this functionality can be achieved using Renovate, remove the old [GH Actions workflow](https://github.com/ScilifelabDataCentre/serve-charts/blob/develop/.github/workflows/bump_chart_version_in_serve_repo.yaml).

**Local dry run:**

```Bash
docker run -e GITHUB_TOKEN -e LOG_LEVEL=info -e LOG_FORMAT=json \
  --rm -v .:/usr/src/app ghcr.io/renovatebot/renovate \
  --dry-run=full --platform local --onboarding=false
```

## Checklist

- [X] This pull request is against **develop** branch (not applicable for hotfixes)
- [X] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [ ] I have added or updated unit and end2end tests or a manual test case to complement my changes
- [ ] I have ran unit and end2end tests
- [ ] I have updated the related documentation (if necessary)
- [x] I have added a reviewer for this pull request
- [X] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts
- [ ] In case your changes are large enough, did you deploy your changes to develop instance?

# PR cheatsheet

- PR -- pull request
- Include jira ticket in the PR title (like `SS-1234 Introduced machine learning ai driven framework for DDLS Fellows from EMBL`)
- To set the status of the pull request, use the built-in github feature to set the PR as Draft or Ready for review.
- To indicate the type of change (such as bugfix or new feature), use a github pull request label.
- If pr is not ready for review, set it draft. We agreed in the team, that if the PR in the draft state, no one will review it.
- Remember, that you can trigger end2end tests manually
