### PR TITLE
ss-1972 Allow non-public app and draft DOI record deletion by user

### DIFF
--- a/apps/views.py
+++ b/apps/views.py
@@ -279,6 +279,15 @@ def delete(request, project, app_slug, app_id):
     ):
         return HttpResponseForbidden("Cannot delete public apps with published DOIs.")
 
+    # Discard any unpublished DOI draft associated with this app
+    if (
+        hasattr(instance, "invenio_record_id")
+        and instance.invenio_record_id
+        and getattr(instance, "access", None) != "public"
+    ):
+        invenio_svc = InvenioService()
+        invenio_svc.delete_draft_record(instance.invenio_record_id)
+
     serialized_instance = instance.serialize()
 
     delete_resource.delay(serialized_instance, AppActionOrigin.USER.value)

--- a/doi_minting/clients/invenio_client/mock_client.py
+++ b/doi_minting/clients/invenio_client/mock_client.py
@@ -99,6 +99,12 @@ class MockInvenioClient:
             }
         return {}
 
+    def delete_draft(self, record_id: str) -> bool:
+        return True
+
+    def delete_doi(self, record_id: str) -> bool:
+        return True
+
     def get_record(self, record_id: str) -> dict[str, Any]:
         # Return empty dict if record_id is None or empty
         if not record_id:

--- a/doi_minting/services/invenio_svc.py
+++ b/doi_minting/services/invenio_svc.py
@@ -434,6 +434,23 @@ class InvenioService:
 
         logger.debug(f"Updated app instance - Record ID: {record_id}, DOI: {doi}")
 
+    def delete_draft_record(self, record_id: str) -> bool:
+        """
+        Discard an unpublished Invenio draft record.
+
+        Args:
+            record_id: The Invenio record ID of the draft to delete.
+        Returns:
+            True if successfully deleted, False otherwise.
+        """
+        try:
+            result = self.client.delete_draft(record_id)
+            logger.info(f"Deleted Invenio draft record {record_id}")
+            return result
+        except Exception:
+            logger.exception(f"Failed to delete Invenio draft record {record_id}")
+            return False
+
     def get_record_data(self, record_id: str) -> Optional[InvenioRecord]:
         """
         Retrieve a published Invenio record for a given Invenio ID as an

--- a/templates/projects/partials/app_instances_table.html
+++ b/templates/projects/partials/app_instances_table.html
@@ -165,7 +165,7 @@
                         </a>
                         {% endif %}
                       {% else %}
-                        {% if instance.access != 'public' and not instance.app_doi|default:False %}
+                        {% if instance.access != 'public' %}
                           {% if instance.app.user_can_delete %}
 
                           <a class="dropdown-item bg-danger text-white confirm-delete default"


### PR DESCRIPTION
## Description

Jira: https://scilifelab.atlassian.net/browse/SS-1972

This change allows the user to delete a non-public app linked to a draft DOI record. Both the app and the draft record will be deleted. Have tested the changes against Serve dev.

## Checklist

> If you're unsure about any of the items below, don't hesitate to ask. We're here to help!
> This is simply a reminder of what we are going to look for before merging your code.

- [X] This pull request is against **develop** branch (not applicable for hotfixes)
- [X] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [ ] I have added or updated unit and end2end tests or a manual test case to complement my changes
- [ ] I have ran unit and end2end tests
- [ ] I have considered accessibility for UI changes and reviewed pre-commit/Pa11y results or documented a manual check
- [ ] I have updated the related documentation (if necessary)
- [X] I have added a reviewer for this pull request
- [X] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts
- [ ] In case your changes are large enough, did you deploy your changes to develop instance?

# PR cheatsheet

- PR -- pull request
- Include jira ticket in the PR title (like `SS-1234 Introduced machine learning ai driven framework for DDLS Fellows from EMBL`)
- To set the status of the pull request, use the built-in github feature to set the PR as Draft or Ready for review.
- To indicate the type of change (such as bugfix or new feature), use a github pull request label.
- If pr is not ready for review, set it draft. We agreed in the team, that if the PR in the draft state, no one will review it.
- Remember, that you can trigger end2end tests manually
