### PR TITLE
SS-1973 fix flickering issue with error poll check

### DIFF
--- a/templates/apps/deployment_progress.html
+++ b/templates/apps/deployment_progress.html
@@ -45,6 +45,9 @@
           <div class="small text-muted mb-4" id="progress-next-step">
             We will open the app details page automatically when everything is ready.
           </div>
+          <div class="small text-warning d-none mb-4" id="progress-poll-warning">
+            Could not load the latest deployment update. Retrying automatically.
+          </div>
 
           <div class="d-flex flex-wrap gap-2">
             <a href="{{ form_url }}" class="btn btn-outline-secondary">Back to form</a>
@@ -102,6 +105,7 @@ const STATUS_LABELS = {
 let progressPoller = null;
 let successRedirectTimer = null;
 let consecutiveSuccessPolls = 0;
+let consecutiveErrorPolls = 0;
 let stepRevealTimer = null;
 let latestServerData = {
   deployment: {
@@ -125,6 +129,13 @@ function stopStepReveal() {
   if (stepRevealTimer) {
     window.clearTimeout(stepRevealTimer);
     stepRevealTimer = null;
+  }
+}
+
+function updatePollWarning(isVisible) {
+  const warning = document.getElementById("progress-poll-warning");
+  if (warning) {
+    warning.classList.toggle("d-none", !isVisible);
   }
 }
 
@@ -379,6 +390,12 @@ function renderProgress(data) {
   updateHeader(data.deployment, steps);
 }
 
+function renderProgressShell(data) {
+  const steps = data.steps || [];
+  updateSummary(steps, data.deployment);
+  updateHeader(data.deployment, steps);
+}
+
 function areSameStep(left, right) {
   return JSON.stringify(left || null) === JSON.stringify(right || null);
 }
@@ -442,7 +459,7 @@ function syncDisplayedProgress() {
       ...displayedProgressData,
       deployment: {...latestServerData.deployment}
     };
-    renderProgress(displayedProgressData);
+    renderProgressShell(displayedProgressData);
     maybeRedirectToDetails(displayedProgressData);
     return;
   }
@@ -485,6 +502,8 @@ function refreshProgress() {
       return response.json();
     })
     .then(data => {
+      consecutiveErrorPolls = 0;
+      updatePollWarning(false);
       const fresh = copyProgressData(data);
 
       if (isProgressSuccessful(fresh)) {
@@ -509,10 +528,8 @@ function refreshProgress() {
     })
     .catch(error => {
       console.error("Error fetching deployment progress:", error);
-      const inline = document.getElementById("progress-inline");
-      if (inline) {
-        inline.textContent = "Could not load the latest deployment update. Retrying automatically.";
-      }
+      consecutiveErrorPolls += 1;
+      updatePollWarning(consecutiveErrorPolls >= 2);
       throw error;
     });
 }


### PR DESCRIPTION
## Description

This PR relates to [SS-1973](https://scilifelab.atlassian.net/browse/SS-1973).

It reduces flicker on the deployment progress page when the status polling endpoint intermittently fails or returns unchanged progress data.

## Checklist

- [x] This pull request is against **develop** branch (not applicable for hotfixes)
- [x] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [ ] I have added or updated unit and end2end tests or a manual test case to complement my changes
- [ ] I have ran unit and end2end tests
- [ ] I have considered accessibility for UI changes and reviewed pre-commit/Pa11y results or documented a manual check
- [ ] I have updated the related documentation (if necessary)
- [ ] I have added a reviewer for this pull request
- [ ] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts
- [ ] In case your changes are large enough, did you deploy your changes to develop instance?
