### PR TITLE
ss-1976 Fix integration and E2E tests

### DIFF
--- a/cypress/e2e/integration-tests/test-deploy-app.cy.js
+++ b/cypress/e2e/integration-tests/test-deploy-app.cy.js
@@ -314,6 +314,8 @@ describe("Test deploying app", () => {
             cy.contains('button', 'Add creator').should('be.visible').click()
             cy.contains('.modal-content', 'Add creator')
                 .should('be.visible')
+            cy.wait(200) // let the modal's delayed auto-focus (setTimeout 150ms) fire before typing, or it steals focus mid-type
+            cy.contains('.modal-content', 'Add creator')
                 .within(() => {
                     cy.get('#newCreatorName').type(creator_firstname)
                     cy.get('#newCreatorLastName').type(creator_lastname)
@@ -328,6 +330,8 @@ describe("Test deploying app", () => {
             cy.contains('button', 'Add creator').should('be.visible').click()
             cy.contains('.modal-content', 'Add creator')
                 .should('be.visible')
+            cy.wait(200) // let the modal's delayed auto-focus (setTimeout 150ms) fire before typing, or it steals focus mid-type
+            cy.contains('.modal-content', 'Add creator')
                 .within(() => {
                     cy.get('#newCreatorOrcid').should('be.visible').type('Jane Doe')
                     cy.get('#orcidSuggestions .list-group-item', { timeout: 10000 }).should('be.visible').first().should('contain', 'Jane Doe').click()

--- a/cypress/e2e/integration-tests/test-deploy-app.cy.js
+++ b/cypress/e2e/integration-tests/test-deploy-app.cy.js
@@ -13,7 +13,7 @@ describe("Test deploying app", () => {
     // Instead use longer timeouts on specific commands where deemed necessary and valid
     const defaultCmdTimeoutMs = 10000
     // The longer timeout is often used when waiting for k8s operations to complete
-    const longCmdTimeoutMs = 60000
+    const longCmdTimeoutMs = 180000
     // Shiny apps have a longer timeout because of special treatment,
     // such as URL probing in the event-listener. Using timeout just over 3 minutes
     const shinyAppCmdTimeoutMs = 183000
@@ -317,8 +317,9 @@ describe("Test deploying app", () => {
             cy.wait(200) // let the modal's delayed auto-focus (setTimeout 150ms) fire before typing, or it steals focus mid-type
             cy.contains('.modal-content', 'Add creator')
                 .within(() => {
-                    cy.get('#newCreatorName').type(creator_firstname)
-                    cy.get('#newCreatorLastName').type(creator_lastname)
+                    cy.get('#newCreatorName').click().type(creator_firstname)
+                    cy.get('#newCreatorName').should('have.value', creator_firstname)
+                    cy.get('#newCreatorLastName').click().type(creator_lastname)
                     cy.get('#newCreatorAffiliation').should('be.visible').type(creator_affiliation)
                     cy.get('#affiliationSuggestions', { timeout: 10000 }).should('be.visible').contains(creator_affiliation)
                     cy.get('#affiliationSuggestions .list-group-item').first().click({ force: true })
@@ -333,8 +334,8 @@ describe("Test deploying app", () => {
             cy.wait(200) // let the modal's delayed auto-focus (setTimeout 150ms) fire before typing, or it steals focus mid-type
             cy.contains('.modal-content', 'Add creator')
                 .within(() => {
-                    cy.get('#newCreatorOrcid').should('be.visible').type('Jane Doe')
-                    cy.get('#orcidSuggestions .list-group-item', { timeout: 10000 }).should('be.visible').first().should('contain', 'Jane Doe').click()
+                    cy.get('#newCreatorOrcid').should('be.visible').click().type('Jane Doe')
+                    cy.get('#orcidSuggestions .list-group-item', { timeout: 20000 }).should('be.visible').first().should('contain', 'Jane Doe').click()
                     cy.get('#newCreatorOrcid').should('have.value', 'https://orcid.org/0000-0002-1584-4316')
                     cy.get('#newCreatorAffiliation').should('have.value', 'Example Research Institute')
                     cy.get('#newCreatorName').should('have.value', 'Jane')

--- a/cypress/e2e/ui-tests/test-user-manage-apps.cy.js
+++ b/cypress/e2e/ui-tests/test-user-manage-apps.cy.js
@@ -202,6 +202,7 @@ if (Cypress.env('create_resources') === true) {
                     cy.get('#saveAndAddAnotherCreatorBtn').should('be.disabled')
                     cy.get('#saveCreatorBtn').should('be.disabled')
                 })
+            cy.wait(350) // let the Bootstrap modal fade-in transition fully finish before dismissing it
             cy.get('#creatorsModal .btn-close').should('be.visible').click()
             cy.get('#creatorsModal').should('not.be.visible')
             cy.get('#addFunderBtn').should('be.visible').click()
@@ -214,6 +215,7 @@ if (Cypress.env('create_resources') === true) {
                     cy.get('#saveAndAddAnotherBtn').should('be.disabled')
                     cy.get('#saveFunderBtn').should('be.disabled')
                 })
+            cy.wait(350) // let the Bootstrap modal fade-in transition fully finish before dismissing it
             cy.get('#funderModal .btn-close').should('be.visible').click()
             cy.get('#funderModal').should('not.be.visible')
             cy.get('#submit-id-submit').should('be.visible').contains('Submit').click()

--- a/templates/apps/partials/creators_modal.html
+++ b/templates/apps/partials/creators_modal.html
@@ -11,7 +11,7 @@
           <div class="col-md-6 position-relative">
             <label for="newCreatorOrcid" class="form-label fw-bold">ORCID ID <small class="text-muted">(optional)</small></label>
             <div class="input-group">
-              <input type="text" class="form-control" id="newCreatorOrcid" placeholder="Name or ORCID ID">
+              <input type="text" class="form-control" id="newCreatorOrcid" placeholder="Name or ORCID ID" autocomplete="off">
               <span class="input-group-text" id="orcidSearchLoading" style="display: none;">
                 <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
               </span>
@@ -23,7 +23,7 @@
           <div class="col-md-6 position-relative">
             <label for="newCreatorAffiliation" class="form-label fw-bold">Affiliation <span class="text-danger">*</span></label>
             <div class="input-group">
-              <input type="text" class="form-control" id="newCreatorAffiliation" placeholder="Affiliation" required>
+              <input type="text" class="form-control" id="newCreatorAffiliation" placeholder="Affiliation" required autocomplete="off">
               <span class="input-group-text" id="affiliationSearchLoading" style="display: none;">
                 <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
               </span>
@@ -35,11 +35,11 @@
           <!-- Name fields - Required and editable -->
           <div class="col-md-6">
             <label for="newCreatorName" class="form-label fw-bold">First Name <span class="text-danger">*</span></label>
-            <input type="text" class="form-control" id="newCreatorName" placeholder="First name" required>
+            <input type="text" class="form-control" id="newCreatorName" placeholder="First name" required autocomplete="off">
           </div>
           <div class="col-md-6">
             <label for="newCreatorLastName" class="form-label fw-bold">Last Name <span class="text-danger">*</span></label>
-            <input type="text" class="form-control" id="newCreatorLastName" placeholder="Last name" required>
+            <input type="text" class="form-control" id="newCreatorLastName" placeholder="Last name" required autocomplete="off">
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Description

Jira: https://scilifelab.atlassian.net/browse/SS-1976

During release v5.1.0, we saw integration test errors relating to the Creator modal input process. This can be fixed by using `click` in the input field before `type`.

Also some timeout changes and a fix for the latest error in the E2E tests by adding a delay so that the Creator modal has enough time to fade out.

## TODO

- [x] E2E tests pass
- [x] Integration tests pass against Serve dev

## Checklist

> If you're unsure about any of the items below, don't hesitate to ask. We're here to help!
> This is simply a reminder of what we are going to look for before merging your code.

- [X] This pull request is against **develop** branch (not applicable for hotfixes)
- [X] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [ ] I have added or updated unit and end2end tests or a manual test case to complement my changes
- [x] I have ran unit and end2end tests
- [ ] I have considered accessibility for UI changes and reviewed pre-commit/Pa11y results or documented a manual check
- [ ] I have updated the related documentation (if necessary)
- [ ] I have added a reviewer for this pull request
- [X] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts
- [ ] In case your changes are large enough, did you deploy your changes to develop instance?

# PR cheatsheet

- PR -- pull request
- Include jira ticket in the PR title (like `SS-1234 Introduced machine learning ai driven framework for DDLS Fellows from EMBL`)
- To set the status of the pull request, use the built-in github feature to set the PR as Draft or Ready for review.
- To indicate the type of change (such as bugfix or new feature), use a github pull request label.
- If pr is not ready for review, set it draft. We agreed in the team, that if the PR in the draft state, no one will review it.
- Remember, that you can trigger end2end tests manually
