### PR TITLE
SS-1988 fix copy api endpoint bug

### DIFF
--- a/portal/cache.py
+++ b/portal/cache.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.core.cache import cache
 
 PUBLIC_APPS_CACHE_KEYS = (
@@ -7,6 +8,27 @@ PUBLIC_APPS_CACHE_KEYS = (
     "portal_public_apps:recent",
 )
 
+EVENTS_CACHE_KEY = "portal_events:page_data"
+NEWS_CACHE_KEY = "portal_news:page_data"
+COLLECTIONS_CACHE_KEY = "portal_collections:index"
+HOME_CACHE_KEY = "portal_home:content_blocks"
+
+
+def get_public_pages_cache_timeout() -> int:
+    return getattr(settings, "PUBLIC_PAGES_CACHE_TIMEOUT", 600)
+
 
 def invalidate_public_apps_cache() -> None:
     cache.delete_many(PUBLIC_APPS_CACHE_KEYS)
+
+
+def invalidate_events_cache() -> None:
+    cache.delete_many([EVENTS_CACHE_KEY, HOME_CACHE_KEY])
+
+
+def invalidate_news_cache() -> None:
+    cache.delete_many([NEWS_CACHE_KEY, HOME_CACHE_KEY])
+
+
+def invalidate_collections_cache() -> None:
+    cache.delete_many([COLLECTIONS_CACHE_KEY, HOME_CACHE_KEY])

--- a/portal/signals.py
+++ b/portal/signals.py
@@ -1,8 +1,31 @@
 import structlog
+from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 from django_structlog.signals import bind_extra_request_metadata
+
+from portal.cache import (
+    invalidate_collections_cache,
+    invalidate_events_cache,
+    invalidate_news_cache,
+)
+from portal.models import Collection, EventsObject, NewsObject
 
 
 @receiver(bind_extra_request_metadata)
 def remove_ip_address(sender, request, logger, **kwargs):
     structlog.contextvars.bind_contextvars(ip=None)
+
+
+@receiver([post_save, post_delete], sender=EventsObject)
+def clear_events_cache(sender, **kwargs):
+    invalidate_events_cache()
+
+
+@receiver([post_save, post_delete], sender=NewsObject)
+def clear_news_cache(sender, **kwargs):
+    invalidate_news_cache()
+
+
+@receiver([post_save, post_delete], sender=Collection)
+def clear_collections_cache(sender, **kwargs):
+    invalidate_collections_cache()

--- a/portal/views.py
+++ b/portal/views.py
@@ -22,6 +22,13 @@ from apps.models import Apps, BaseAppInstance, SocialMixin
 from common.tasks import send_email_task
 from studio.utils import get_logger
 
+from .cache import (
+    COLLECTIONS_CACHE_KEY,
+    EVENTS_CACHE_KEY,
+    HOME_CACHE_KEY,
+    NEWS_CACHE_KEY,
+    get_public_pages_cache_timeout,
+)
 from .forms import TeachingRequestForm
 from .models import EventsObject, NewsObject
 
@@ -399,43 +406,36 @@ class HomeView(View):
     def get(self, request, app_id=0):
         published_apps_updated_on = _get_recent_public_apps()
 
-        news_objects = NewsObject.objects.all().order_by("-created_on")
-        link_all_news = False
-        if news_objects.count() > 3:
+        home_blocks = cache.get(HOME_CACHE_KEY)
+        if home_blocks is None:
+            news_objects = list(NewsObject.objects.all().order_by("-created_on"))
+            link_all_news = len(news_objects) > 3
             news_objects = news_objects[:3]
-            link_all_news = True
-        else:
-            news_objects = news_objects
-        for news in news_objects:
-            news.body_html = markdown.markdown(news.body)
+            for news in news_objects:
+                news.body_html = markdown.markdown(news.body)
 
-        collection_objects = Collection.objects.all().order_by("-created_on")
-        link_all_collections = False
-        if collection_objects.count() > 3:
+            collection_objects = list(Collection.objects.all().order_by("-created_on"))
+            link_all_collections = len(collection_objects) > 3
             collection_objects = collection_objects[:3]
-            link_all_collections = True
-        else:
-            collection_objects = collection_objects
 
-        events_objects = EventsObject.objects.all().order_by("-start_time")
-        link_all_events = False
-        if events_objects.count() > 3:
-            link_all_events = True
+            events_objects = list(EventsObject.objects.all().order_by("-start_time"))
+            link_all_events = len(events_objects) > 3
             events_objects = events_objects[:3]
-        else:
-            events_objects = events_objects
-        for event in events_objects:
-            event.description_html = markdown.markdown(event.description)
-            event.past = True if event.start_time.date() < timezone.now().date() else False
-        context = {
-            "published_apps_updated_on": published_apps_updated_on,
-            "news_objects": news_objects,
-            "link_all_news": link_all_news,
-            "collection_objects": collection_objects,
-            "link_all_collections": link_all_collections,
-            "events_objects": events_objects,
-            "link_all_events": link_all_events,
-        }
+            for event in events_objects:
+                event.description_html = markdown.markdown(event.description)
+                event.past = event.start_time.date() < timezone.now().date()
+
+            home_blocks = {
+                "news_objects": news_objects,
+                "link_all_news": link_all_news,
+                "collection_objects": collection_objects,
+                "link_all_collections": link_all_collections,
+                "events_objects": events_objects,
+                "link_all_events": link_all_events,
+            }
+            cache.set(HOME_CACHE_KEY, home_blocks, timeout=get_public_pages_cache_timeout())
+
+        context = {"published_apps_updated_on": published_apps_updated_on, **home_blocks}
 
         return render(request, self.template, context=context)
 
@@ -521,16 +521,22 @@ def privacy(request):
 
 
 def get_news(request):
-    news_objects = NewsObject.objects.all().order_by("-created_on")
-    for news in news_objects:
-        news.body_html = markdown.markdown(news.body)
+    news_objects = cache.get(NEWS_CACHE_KEY)
+    if news_objects is None:
+        news_objects = list(NewsObject.objects.all().order_by("-created_on"))
+        for news in news_objects:
+            news.body_html = markdown.markdown(news.body)
+        cache.set(NEWS_CACHE_KEY, news_objects, timeout=get_public_pages_cache_timeout())
     return render(request, "news/news.html", {"news_objects": news_objects})
 
 
 def get_collections_index(request):
     template = "collections/index.html"
 
-    collection_objects = Collection.objects.all().order_by("-created_on")
+    collection_objects = cache.get(COLLECTIONS_CACHE_KEY)
+    if collection_objects is None:
+        collection_objects = list(Collection.objects.all().order_by("-created_on"))
+        cache.set(COLLECTIONS_CACHE_KEY, collection_objects, timeout=get_public_pages_cache_timeout())
 
     context = {"collection_objects": collection_objects}
 
@@ -560,13 +566,21 @@ def get_collection(request, slug, app_id=0):
 
 
 def get_events(request):
-    future_events = EventsObject.objects.filter(start_time__date__gte=timezone.now().date()).order_by("start_time")
-    for event in future_events:
-        event.description_html = markdown.markdown(event.description)
-    past_events = EventsObject.objects.filter(start_time__date__lt=timezone.now().date()).order_by("-start_time")
-    for event in past_events:
-        event.description_html = markdown.markdown(event.description)
-    return render(request, "events/events.html", {"future_events": future_events, "past_events": past_events})
+    events = cache.get(EVENTS_CACHE_KEY)
+    if events is None:
+        future_events = list(
+            EventsObject.objects.filter(start_time__date__gte=timezone.now().date()).order_by("start_time")
+        )
+        for event in future_events:
+            event.description_html = markdown.markdown(event.description)
+        past_events = list(
+            EventsObject.objects.filter(start_time__date__lt=timezone.now().date()).order_by("-start_time")
+        )
+        for event in past_events:
+            event.description_html = markdown.markdown(event.description)
+        events = {"future_events": future_events, "past_events": past_events}
+        cache.set(EVENTS_CACHE_KEY, events, timeout=get_public_pages_cache_timeout())
+    return render(request, "events/events.html", events)
 
 
 class EventsFeed(Feed):

--- a/portal/views.py
+++ b/portal/views.py
@@ -27,6 +27,14 @@ from .models import EventsObject, NewsObject
 
 logger = get_logger(__name__)
 
+API_ENDPOINT_APP_SLUGS = frozenset(
+    {
+        "pytorch-serve",
+        "python-serve",
+        "tensorflow-serve",
+    }
+)
+
 
 Project = apps.get_model(app_label=settings.PROJECTS_MODEL)
 PublishedModel = apps.get_model(app_label=settings.PUBLISHEDMODEL_MODEL)
@@ -105,6 +113,10 @@ def __get_content_stats() -> dict[str, int]:
     }
     cache.set(cache_key, stats, timeout=_get_public_apps_cache_timeout())
     return stats
+
+
+def _is_api_endpoint_slug(slug: str | None) -> bool:
+    return slug in API_ENDPOINT_APP_SLUGS
 
 
 def _get_public_apps_cache_timeout() -> int:
@@ -265,6 +277,7 @@ def add_additional_context_to_public_apps(published_apps):
                 "logo": app.app.logo,
                 "slug": app.app.slug,
                 "app_type": "Shiny App" if app.app.name == "ShinyProxy App" else app.app.name,
+                "is_api_endpoint": _is_api_endpoint_slug(app.app.slug),
                 "project_slug": app.project.slug,
                 "source_code_url": app.source_code_url,
                 "status_group": app.status_group,

--- a/studio/error_views.py
+++ b/studio/error_views.py
@@ -7,7 +7,7 @@ opened on the ASGI error path.
 
 from __future__ import annotations
 
-from django.http import HttpResponse, HttpRequest
+from django.http import HttpRequest, HttpResponse
 from django.template import loader
 
 

--- a/studio/error_views.py
+++ b/studio/error_views.py
@@ -1,0 +1,29 @@
+"""
+Error handlers that render without touching the database.
+
+Rendering with ``request=None`` skips context processors, so no DB connection is
+opened on the ASGI error path.
+"""
+
+from __future__ import annotations
+
+from django.http import HttpResponse, HttpRequest
+from django.template import loader
+
+
+def _render_static(template_name: str, status: int) -> HttpResponse:
+    # request=None => no context processors => no DB access.
+    template = loader.get_template(template_name)
+    return HttpResponse(template.render({}), status=status)
+
+
+def handler403(request: HttpRequest, exception: Exception | None = None) -> HttpResponse:
+    return _render_static("403.html", 403)
+
+
+def handler404(request: HttpRequest, exception: Exception | None = None) -> HttpResponse:
+    return _render_static("404.html", 404)
+
+
+def handler500(request: HttpRequest) -> HttpResponse:
+    return _render_static("500.html", 500)

--- a/studio/urls.py
+++ b/studio/urls.py
@@ -28,6 +28,11 @@ from studio.metrics import metrics_view
 
 from . import views
 
+# DB-free error handlers, to avoid leaking pooled connections on the ASGI error
+handler403 = "studio.error_views.handler403"
+handler404 = "studio.error_views.handler404"
+handler500 = "studio.error_views.handler500"
+
 urlpatterns = (
     [
         path(settings.DJANGO_ADMIN_URL_PATH.rstrip("/") + "/", admin.site.urls, name="django-admin"),

--- a/templates/403.html
+++ b/templates/403.html
@@ -1,22 +1,59 @@
-{% extends 'base.html' %}
+<!DOCTYPE html>
+<html lang="en">
 
-{% block title %}Forbidden{% endblock %}
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Access forbidden (403) — SciLifeLab Serve</title>
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Cpath fill='%23a7c947' d='M16 2 L30 28 L2 28 Z'/%3E%3Cpath fill='%23FFFFFF' d='M14 12 h4 v8 h-4 z'/%3E%3Ccircle fill='%23FFFFFF' cx='16' cy='24' r='2'/%3E%3C/svg%3E">
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            text-align: center;
+            padding: 50px;
+            background-color: #f5f5f5;
+        }
+        .container {
+            max-width: 500px;
+            margin: 0 auto;
+            background: white;
+            padding: 40px;
+            border-radius: 8px;
+        }
+        h1 {
+            font-size: 1.6em;
+        }
+        .btn {
+            background: #a7c947;
+            padding: 14px 28px;
+            color: black;
+            text-decoration: none;
+            border-radius: 6px;
+            display: inline-block;
+            font-size: 16px;
+            margin: 20px 8px 0;
+        }
+        .btn:hover {
+            background: #95b03a;
+        }
+        @media (max-width: 768px) {
+            body { padding: 10px; }
+            .container { padding: 30px 15px; margin: 10px; }
+            h1 { font-size: 1.3em; }
+            .btn { padding: 12px 16px; font-size: 14px; }
+        }
+    </style>
+</head>
 
-{% load static %}
+<body>
+    <div class="container">
+        <h1>Access to page forbidden (403 error)</h1>
+        <p>You don't have access to this project. Log in, or ask the project owner to grant you access.</p>
+        <div>
+            <a href="/accounts/login/" class="btn">Log in</a>
+            <a href="/" class="btn">Home</a>
+        </div>
+    </div>
+</body>
 
-{% block content %}
-	<h1>Access to page forbidden. Error 403.</h1>
-	<p>You don't have access to this project! Log in or ask the project owner to grant you access.</p>
-	<p>
-		Is this your project?
-		{% if request.user.is_authenticated %}
-			<a class="btn" href="{% url 'logout' %}">
-				<i class="bi bi-box-arrow-right me-1"></i> Sign out
-			</a>
-		{% else %}
-			<a class="btn btn-profile text-dark" href="{% url 'login' %}">
-				<i class="bi bi-box-arrow-in-right"></i> Log in
-			</a>
-		{% endif %}
-	</p>
-{% endblock %}
+</html>

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,11 +1,58 @@
-{% extends 'base.html' %}
+<!DOCTYPE html>
+<html lang="en">
 
-{% block title %}Forbidden{% endblock %}
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Page not found (404) — SciLifeLab Serve</title>
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Cpath fill='%23a7c947' d='M16 2 L30 28 L2 28 Z'/%3E%3Cpath fill='%23FFFFFF' d='M14 12 h4 v8 h-4 z'/%3E%3Ccircle fill='%23FFFFFF' cx='16' cy='24' r='2'/%3E%3C/svg%3E">
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            text-align: center;
+            padding: 50px;
+            background-color: #f5f5f5;
+        }
+        .container {
+            max-width: 500px;
+            margin: 0 auto;
+            background: white;
+            padding: 40px;
+            border-radius: 8px;
+        }
+        h1 {
+            font-size: 1.6em;
+        }
+        .btn {
+            background: #a7c947;
+            padding: 14px 28px;
+            color: black;
+            text-decoration: none;
+            border-radius: 6px;
+            display: inline-block;
+            font-size: 16px;
+            margin-top: 20px;
+        }
+        .btn:hover {
+            background: #95b03a;
+        }
+        @media (max-width: 768px) {
+            body { padding: 10px; }
+            .container { padding: 30px 15px; margin: 10px; }
+            h1 { font-size: 1.3em; }
+            .btn { padding: 12px 16px; font-size: 14px; }
+        }
+    </style>
+</head>
 
-{% load static %}
+<body>
+    <div class="container">
+        <h1>Page cannot be <i>served</i> 🥁 (404 error)</h1>
+        <p>It's okay, don't worry. Just go back to the home page and try what you wanted to do again.</p>
+        <div>
+            <a href="/" class="btn">Home</a>
+        </div>
+    </div>
+</body>
 
-{% block content %}
-  <h1>Page cannot be <i>served</i> 🥁 (404 error)</h1>
-  <p style="font-size: x-large">It's okay, don't worry. Just go to the <a href="{% url 'portal:home' %}">home page</a>
-    and try what you wanted to do again.</p>
-{% endblock %}
+</html>

--- a/templates/common/app_card.html
+++ b/templates/common/app_card.html
@@ -109,7 +109,7 @@
                             <a id="source-code-url-{{ app.id }}" target="_blank" title="Source code of the app" rel="Link to the source code of the app" href="{{ app.source_code_url }}" class="btn btn-outline-serve btn-sm"> <i class="bi bi-code-slash"></i> Source code</a>
                             {% endif %}
                             </div>
-                            {% if "Serve" in app.name or app.name == "Python Model Deployment" %}
+                            {% if app.is_api_endpoint %}
                                 <a class="btn btn-primary btn-sm" onclick="copyClip('{{app.url}}')">Copy API Endpoint</a>
                             {% else %}
                                 <a title="Launch the app" rel="Link to launch the app" href="{{ app.url }}" target="_blank" class="btn btn-primary btn-sm">Launch</a>


### PR DESCRIPTION
## Description

This PR relates to [SS-1988](https://scilifelab.atlassian.net/browse/SS-1988).

Fixes public app cards incorrectly showing **Copy API Endpoint** when the app title contains “Serve,” such as “CellGPS StructureMap Serve.”

- Classifies API endpoints using the registered app-type slug instead of the user-defined app title.
- Limits **Copy API Endpoint** to TensorFlow Serving, PyTorch Serve, and Python Model Deployment.
- Shows **Launch** for hosted applications such as Gradio, regardless of their title.

## Checklist

- [x] This pull request is against **develop** branch (not applicable for hotfixes)
- [x] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes) — not applicable
- [ ] I have added or updated unit and end2end tests or a manual test case to complement my changes
- [ ] I have ran unit and end2end tests
- [x] I have considered accessibility for UI changes and reviewed pre-commit/Pa11y results or documented a manual check
- [ ] I have updated the related documentation (if necessary) — not applicable
- [ ] I have added a reviewer for this pull request
- [ ] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts — not applicable
- [ ] In case your changes are large enough, did you deploy your changes to develop instance?