### PR TITLE
SS-1991 Allow larger upload sizes

### DIFF
--- a/apps/models/app_types/depictio.py
+++ b/apps/models/app_types/depictio.py
@@ -63,6 +63,7 @@ class DepictioInstance(BaseAppInstance, SocialMixin):
                                 f"}}\n"
                                 f"location = /_depictio_auth {{\n"
                                 f"    internal;\n"
+                                f"    client_max_body_size {self.upload_size}M;\n"
                                 f"    proxy_pass {settings.AUTH_PROTOCOL}://{settings.AUTH_DOMAIN}:8080/auth/?release={self.subdomain.subdomain};\n"
                                 f"    proxy_pass_request_body off;\n"
                                 f'    proxy_set_header Content-Length "";\n'

--- a/fixtures/apps_fixtures.json
+++ b/fixtures/apps_fixtures.json
@@ -2,7 +2,7 @@
   {
     "fields": {
       "category": "develop",
-      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/lab:1.0.9",
+      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/lab:1.0.10",
       "created_on": "2021-02-19T21:34:37.815Z",
       "description": "",
       "gpu_enabled": true,
@@ -21,7 +21,7 @@
   {
     "fields": {
       "category": "manage-files",
-      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/filemanager:1.0.8",
+      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/filemanager:1.0.9",
       "created_on": "2021-02-19T21:34:37.815Z",
       "description": "",
       "logo": "filemanager-logo.svg",
@@ -176,7 +176,7 @@
   {
     "fields": {
       "category": "develop",
-      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/vscode:1.0.7",
+      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/vscode:1.0.8",
       "created_on": "2025-03-12T12:10:37.815Z",
       "description": "",
       "gpu_enabled": true,
@@ -215,7 +215,7 @@
   {
     "fields": {
       "category": "serve",
-      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/custom-app:1.1.6",
+      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/custom-app:1.1.7",
       "created_on": "2023-08-25T21:34:37.815Z",
       "description": "Apps built with Gradio, Streamlit, Flask, etc.",
       "gpu_enabled": true,
@@ -234,7 +234,7 @@
   {
     "fields": {
       "category": "develop",
-      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/rstudio:1.0.8",
+      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/rstudio:1.0.9",
       "created_on": "2023-08-31T09:30:00.000Z",
       "description": "",
       "gpu_enabled": true,
@@ -253,7 +253,7 @@
   {
     "fields": {
       "category": "serve",
-      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/dash-app:1.0.7",
+      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/dash-app:1.0.8",
       "created_on": "2023-08-25T21:34:37.815Z",
       "description": "",
       "gpu_enabled": true,
@@ -272,7 +272,7 @@
   {
     "fields": {
       "category": "serve",
-      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/shinyapp:1.0.8",
+      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/shinyapp:1.0.9",
       "created_on": "2023-08-25T21:34:37.815Z",
       "description": "",
       "logo": "shinyapp-logo.svg",
@@ -290,7 +290,7 @@
   {
     "fields": {
       "category": "serve",
-      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/shinyproxy:1.4.9",
+      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/shinyproxy:1.4.10",
       "created_on": "2023-08-25T21:34:37.815Z",
       "description": "",
       "logo": "shinyapp-logo.svg",
@@ -377,7 +377,7 @@
   {
     "fields": {
       "category": "serve",
-      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/tissuumaps:1.0.7",
+      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/tissuumaps:1.0.8",
       "created_on": "2023-08-25T21:34:37.815Z",
       "description": "App to visualise and explore data using TissUUmaps.",
       "logo": "tissuumaps-logo.svg",
@@ -395,7 +395,7 @@
   {
     "fields": {
       "category": "serve",
-      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/custom-app:1.1.6",
+      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/custom-app:1.1.7",
       "created_on": "2023-08-25T21:34:37.815Z",
       "description": "",
       "gpu_enabled": true,
@@ -414,7 +414,7 @@
   {
     "fields": {
       "category": "serve",
-      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/custom-app:1.1.6",
+      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/custom-app:1.1.7",
       "created_on": "2023-08-25T21:34:37.815Z",
       "description": "",
       "gpu_enabled": true,


### PR DESCRIPTION
## Description

This PR relates to [SS-1991](https://scilifelab.atlassian.net/browse/SS-1991).

This updates Serve to use application chart releases that allow large uploads through authenticated Gateway API routes.

- Adds the configured upload limit to Depictio’s internal authentication location.
- Updates the fixture for File Manager, Jupyter Lab, VS Code, Custom App, RStudio, Dash, Shiny, ShinyProxy, and TissUUmaps.

The issue was seen in a staging File Manager instance. The application route allowed large requests, but the internal authentication subrequest retained NGINX’s 1 MB default and returned `413`.

## Checklist

- [x] This pull request is against **develop** branch (not applicable for hotfixes)
- [x] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (not applicable; no model class changes requiring migrations)
- [ ] I have added or updated unit and end2end tests or a manual test case to complement my changes
- [ ] I have ran unit and end2end tests
- [x] I have considered accessibility for UI changes and reviewed pre-commit/Pa11y results or documented a manual check (not applicable; no UI changes)
- [ ] I have updated the related documentation (not applicable; no documentation changes needed)
- [ ] I have added a reviewer for this pull request
- [ ] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts (not applicable; settings.py was not modified)
- [ ] In case your changes are large enough, did you deploy your changes to develop instance?