### PR TITLE
SS-1992 Add Gateway env variables in app base

### DIFF
--- a/apps/models/base/base.py
+++ b/apps/models/base/base.py
@@ -300,6 +300,17 @@ class BaseAppInstance(models.Model):
             auth_domain=settings.AUTH_DOMAIN,
             protocol=settings.AUTH_PROTOCOL,
         )
+
+        k8s_values["gateway"] = dict(
+            enabled=settings.GATEWAY_ENABLED,
+            name=settings.GATEWAY_NAME,
+            namespace=settings.GATEWAY_NAMESPACE,
+            domainSectionName=settings.GATEWAY_DOMAIN_SECTION_NAME,
+            studioSectionName=settings.GATEWAY_STUDIO_SECTION_NAME,
+            sectionName=settings.GATEWAY_SECTION_NAME,
+            port=settings.GATEWAY_PORT,
+        )
+
         return k8s_values
 
     def set_k8s_values(self):

--- a/studio/settings.py
+++ b/studio/settings.py
@@ -451,18 +451,18 @@ CHART_FOLDER = "/app/charts/apps"
 EXTERNAL_KUBECONF = True
 KUBECONFIG = "/app/cluster.conf"
 NAMESPACE = "default"
-GATEWAY_NAME = os.getenv("GATEWAY_NAME", "default")
-GATEWAY_NAMESPACE = os.getenv("GATEWAY_NAMESPACE", "gateway")
-GATEWAY_SECTION_NAME = os.getenv("GATEWAY_SECTION_NAME", "serve-dev-subdomains")
-GATEWAY_PORT = int(os.getenv("GATEWAY_PORT", "80"))
-KUBE_API_REQUEST_TIMEOUT = 1
-STORAGECLASS = "local-path"
 
+# Gateway API variables
 GATEWAY_ENABLED = os.getenv("GATEWAY_ENABLED", "false").lower() in ("true", "1", "yes")
-GATEWAY_NAME = os.getenv("GATEWAY_NAME", "")
+GATEWAY_NAME = os.getenv("GATEWAY_NAME", "default")
 GATEWAY_NAMESPACE = os.getenv("GATEWAY_NAMESPACE", "")
 GATEWAY_SECTION_NAME = os.getenv("GATEWAY_SECTION_NAME", "")
-GATEWAY_PORT = int(os.getenv("GATEWAY_PORT", "443"))
+GATEWAY_STUDIO_SECTION_NAME = os.getenv("GATEWAY_STUDIO_SECTION_NAME", "")
+GATEWAY_DOMAIN_SECTION_NAME = os.getenv("GATEWAY_DOMAIN_SECTION_NAME", "")
+GATEWAY_PORT = int(os.getenv("GATEWAY_PORT", 80))
+
+KUBE_API_REQUEST_TIMEOUT = 1
+STORAGECLASS = "local-path"
 
 # Docker hub API
 DOCKER_HUB_REPO_SEARCH = "https://hub.docker.com/v2/search/repositories"


### PR DESCRIPTION
## Description

Jira: https://scilifelab.atlassian.net/browse/SS-1992

Gateway API variables need to be baked into k8s_values during app creation from Serve's backend. In addition to cleaning up `settings.py` duplicated variables.

## TODO

- [x] Serve's local Helm deployment works
- [x] Works on Serve dev

## Checklist

> If you're unsure about any of the items below, don't hesitate to ask. We're here to help!
> This is simply a reminder of what we are going to look for before merging your code.

- [X] This pull request is against **develop** branch (not applicable for hotfixes)
- [X] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [ ] I have added or updated unit and end2end tests or a manual test case to complement my changes
- [ ] I have ran unit and end2end tests
- [ ] I have considered accessibility for UI changes and reviewed pre-commit/Pa11y results or documented a manual check
- [ ] I have updated the related documentation (if necessary)
- [ ] I have added a reviewer for this pull request
- [X] I have added myself as an author for this pull request
- [X] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts
- [ ] In case your changes are large enough, did you deploy your changes to develop instance?

# PR cheatsheet

- PR -- pull request
- Include jira ticket in the PR title (like `SS-1234 Introduced machine learning ai driven framework for DDLS Fellows from EMBL`)
- To set the status of the pull request, use the built-in github feature to set the PR as Draft or Ready for review.
- To indicate the type of change (such as bugfix or new feature), use a github pull request label.
- If pr is not ready for review, set it draft. We agreed in the team, that if the PR in the draft state, no one will review it.
- Remember, that you can trigger end2end tests manually
