### PR TITLE
SS-1993 MLflow app redeploys on name change

### DIFF
--- a/apps/forms/mlflow.py
+++ b/apps/forms/mlflow.py
@@ -32,6 +32,20 @@ class MLFlowAppForm(BaseForm):
 
         self.helper.layout = Layout(body, self.footer)
 
+    def clean_subdomain(self):
+        if self.instance and self.instance.pk and "subdomain" not in self.data and self.instance.subdomain:
+            return self.validate_subdomain(self.instance.subdomain.subdomain)
+
+        return super().clean_subdomain()
+
+    @property
+    def changed_data(self):
+        changed_data = super().changed_data
+        if self.instance and self.instance.pk and "subdomain" not in self.data and "subdomain" in changed_data:
+            changed_data.remove("subdomain")
+
+        return changed_data
+
     class Meta:
         model = MLFlowInstance
         fields = ["name"]

--- a/apps/helpers.py
+++ b/apps/helpers.py
@@ -1383,7 +1383,7 @@ def generate_helm_install_command(
                 chart = match.group("chart")
                 parsed_version = match.group("version")
 
-    no_force_charts = ("volumek8s", "depictio")
+    no_force_charts = ("volumek8s", "depictio", "mlflow")
     if any(name in chart for name in no_force_charts):
         command = f"helm upgrade --install {release_name} {chart} --namespace {namespace}"
     else:

--- a/apps/helpers.py
+++ b/apps/helpers.py
@@ -1383,7 +1383,7 @@ def generate_helm_install_command(
                 chart = match.group("chart")
                 parsed_version = match.group("version")
 
-    no_force_charts = ("volumek8s", "depictio", "mlflow")
+    no_force_charts = ("volumek8s", "depictio")
     if any(name in chart for name in no_force_charts):
         command = f"helm upgrade --install {release_name} {chart} --namespace {namespace}"
     else:


### PR DESCRIPTION
## Description

Jira: https://scilifelab.atlassian.net/browse/SS-1993

When changing an MLflow app's name from Settings from Serve's UI, the subdomain field gets logged as changed when it hasn't, this triggers a redeployment of the app.

This PR adds cleanup code for MLflow's form fields similar to what is done in the other apps.

## TODO

- [x] test this out on Serve dev

## Checklist

> If you're unsure about any of the items below, don't hesitate to ask. We're here to help!
> This is simply a reminder of what we are going to look for before merging your code.

- [X] This pull request is against **develop** branch (not applicable for hotfixes)
- [X] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [ ] I have added or updated unit and end2end tests or a manual test case to complement my changes
- [ ] I have ran unit and end2end tests
- [ ] I have considered accessibility for UI changes and reviewed pre-commit/Pa11y results or documented a manual check
- [ ] I have updated the related documentation (if necessary)
- [ ] I have added a reviewer for this pull request
- [X] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts
- [ ] In case your changes are large enough, did you deploy your changes to develop instance?

# PR cheatsheet

- PR -- pull request
- Include jira ticket in the PR title (like `SS-1234 Introduced machine learning ai driven framework for DDLS Fellows from EMBL`)
- To set the status of the pull request, use the built-in github feature to set the PR as Draft or Ready for review.
- To indicate the type of change (such as bugfix or new feature), use a github pull request label.
- If pr is not ready for review, set it draft. We agreed in the team, that if the PR in the draft state, no one will review it.
- Remember, that you can trigger end2end tests manually
