### PR TITLE
SS-925 status update isolation

### DIFF
--- a/apps/tests/test_cross_project_app_access.py
+++ b/apps/tests/test_cross_project_app_access.py
@@ -1,0 +1,120 @@
+"""Tests that the app views under /projects/<project>/apps/ scope app lookups to the project.
+
+Each test calls an endpoint under a project the logged-in user owns, but passes the id of an
+app belonging to another user's project, and asserts the app is treated as non-existent. One
+test covers the same endpoint with an app from the user's own project to confirm it still
+resolves.
+"""
+
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.test import Client, TestCase
+
+from projects.models import Project
+
+from ..models import AppCategories, Apps, BackgroundTask, JupyterInstance, K8sUserAppStatus, Subdomain
+
+User = get_user_model()
+
+user_1 = {"username": "user1@test.com", "email": "user1@test.com", "password": "bar"}
+user_2 = {"username": "user2@test.com", "email": "user2@test.com", "password": "bar"}
+
+
+class CrossProjectAppAccessTestCase(TestCase):
+    """User 1 must not reach apps that live in user 2's project."""
+
+    def setUp(self) -> None:
+        self.user_1 = User.objects.create_user(user_1["username"], user_1["email"], user_1["password"])
+        self.user_2 = User.objects.create_user(user_2["username"], user_2["email"], user_2["password"])
+
+        self.category = AppCategories.objects.create(name="Network", priority=100, slug="network")
+        self.app = Apps.objects.create(
+            name="Jupyter Lab",
+            slug="jupyter-lab",
+            user_can_delete=True,
+            category=self.category,
+        )
+
+        # User 1 owns a project of their own, so they pass the permission check on the
+        # project slug in the URL.
+        self.project_1 = Project.objects.create_project(name="project-one", owner=self.user_1, description="")
+        self.project_2 = Project.objects.create_project(name="project-two", owner=self.user_2, description="")
+
+        self.app_2 = JupyterInstance.objects.create(
+            access="private",
+            owner=self.user_2,
+            name="app_in_project_two",
+            app=self.app,
+            project=self.project_2,
+            subdomain=Subdomain.objects.create(subdomain="project_two_internal"),
+            k8s_user_app_status=K8sUserAppStatus.objects.create(),
+        )
+
+        self.client = Client()
+        logged_in = self.client.login(username=user_1["email"], password=user_1["password"])
+        self.assertTrue(logged_in)
+
+    def url(self, path):
+        """Build a URL under user 1's own project."""
+        return f"/projects/{self.project_1.slug}/apps/{path}"
+
+    def test_status_does_not_leak_apps_from_other_projects(self):
+        response = self.client.post(self.url("status"), {"apps": [self.app_2.id]})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {})
+
+    def test_status_still_returns_apps_in_own_project(self):
+        app_1 = JupyterInstance.objects.create(
+            access="private",
+            owner=self.user_1,
+            name="app_in_project_one",
+            app=self.app,
+            project=self.project_1,
+            subdomain=Subdomain.objects.create(subdomain="project_one_internal"),
+            k8s_user_app_status=K8sUserAppStatus.objects.create(),
+        )
+
+        response = self.client.post(self.url("status"), {"apps": [app_1.id]})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(f"{self.app.slug}-{app_1.pk}", response.json())
+
+    def test_logs_page_from_other_project_is_not_found(self):
+        response = self.client.get(self.url(f"logs/{self.app.slug}/{self.app_2.id}"))
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_logs_query_from_other_project_is_not_found(self):
+        response = self.client.post(self.url(f"logs/{self.app.slug}/{self.app_2.id}"), {"container": ""})
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_delete_from_other_project_is_forbidden(self):
+        with patch("apps.tasks.delete_resource.delay") as mock_task:
+            response = self.client.get(self.url(f"delete/{self.app.slug}/{self.app_2.id}"))
+
+        self.assertEqual(response.status_code, 403)
+        mock_task.assert_not_called()
+
+        self.app_2.refresh_from_db()
+        self.assertIsNone(self.app_2.deleted_on)
+
+    def test_secrets_from_other_project_is_not_found(self):
+        response = self.client.get(self.url(f"secrets/{self.app.slug}/{self.app_2.id}"))
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_retry_background_task_from_other_project_is_not_found(self):
+        task = BackgroundTask.objects.create(
+            app_instance=self.app_2,
+            task_name="deploy_resource",
+            status="failed",
+        )
+
+        with patch("apps.tasks.retry_background_task.delay") as mock_task:
+            response = self.client.post(self.url(f"tasks/{self.app.slug}/{self.app_2.id}/{task.id}/retry"))
+
+        self.assertEqual(response.status_code, 404)
+        mock_task.assert_not_called()

--- a/apps/tests/test_cross_project_app_access.py
+++ b/apps/tests/test_cross_project_app_access.py
@@ -13,7 +13,14 @@ from django.test import Client, TestCase
 
 from projects.models import Project
 
-from ..models import AppCategories, Apps, BackgroundTask, JupyterInstance, K8sUserAppStatus, Subdomain
+from ..models import (
+    AppCategories,
+    Apps,
+    BackgroundTask,
+    JupyterInstance,
+    K8sUserAppStatus,
+    Subdomain,
+)
 
 User = get_user_model()
 

--- a/apps/views.py
+++ b/apps/views.py
@@ -113,10 +113,16 @@ def _build_background_task_status_cache_key(
 class GetLogs(View):
     template = "apps/logs.html"
 
-    def get_instance(self, app_slug, app_id, post=False):
+    def get_instance(self, project, app_slug, app_id, post=False):
         model_class = APP_REGISTRY.get_orm_model(app_slug)
         if model_class:
-            return model_class.objects.get(pk=app_id)
+            try:
+                return model_class.objects.get(pk=app_id, project=project)
+            except model_class.DoesNotExist as exc:
+                message = "An app with this id does not exist in this project."
+                if post:
+                    return JsonResponse({"error": message}, status=404)
+                raise Http404(message) from exc
         else:
             message = f"Could not find model for slug {app_slug}"
             if post:
@@ -139,7 +145,7 @@ class GetLogs(View):
 
     def get(self, request, project, app_slug, app_id):
         project = self.get_project(project)
-        instance = self.get_instance(app_slug, app_id)
+        instance = self.get_instance(project, app_slug, app_id)
 
         context = {"instance": instance, "project": project}
         return render(request, self.template, context)
@@ -147,7 +153,11 @@ class GetLogs(View):
     def post(self, request, project, app_slug, app_id):
         # Validate project and instance existence
         project = self.get_project(project, post=True)
-        instance = self.get_instance(app_slug, app_id, post=True)
+        if isinstance(project, JsonResponse):
+            return project
+        instance = self.get_instance(project, app_slug, app_id, post=True)
+        if isinstance(instance, JsonResponse):
+            return instance
 
         # get container name from UI (subdomain or copy-to-pvc) if none exists then use subdomain name
         container = request.POST.get("container", "") or instance.subdomain.subdomain
@@ -225,7 +235,7 @@ class GetStatusView(CachedProjectPermissionRequiredMixin):
             arr = body.split(",")
 
             for orm_model in APP_REGISTRY.iter_orm_models():
-                instances = orm_model.objects.filter(pk__in=arr)
+                instances = orm_model.objects.filter(pk__in=arr, project__slug=project)
 
                 for instance in instances:
                     status = instance.get_app_status()
@@ -261,7 +271,7 @@ def delete(request, project, app_slug, app_id):
     if model_class is None:
         raise PermissionDenied()
 
-    instance = model_class.objects.get(pk=app_id) if app_id else None
+    instance = model_class.objects.filter(pk=app_id, project__slug=project).first() if app_id else None
 
     if instance is None:
         raise PermissionDenied()
@@ -580,7 +590,7 @@ class SecretsView(View):
     template = "apps/secrets_view.html"
 
     def get(self, request, project, app_slug, app_id):
-        instance: BaseAppInstance = APP_REGISTRY.get_orm_model(app_slug).objects.get(pk=app_id)
+        _, instance = get_project_app_instance(project, app_slug, app_id)
 
         username, password = None, None
         if instance.get_app_status() == "Running":
@@ -990,7 +1000,7 @@ class RetryBackgroundTaskView(View):
             return JsonResponse({"error": "Application model not found"}, status=404)
 
         try:
-            instance = model_class.objects.get(pk=app_id)
+            instance = model_class.objects.get(pk=app_id, project__slug=project)
         except model_class.DoesNotExist:
             return JsonResponse({"error": "App instance not found"}, status=404)
         if _should_restrict_deployment_details(request, instance):


### PR DESCRIPTION
## Description

This PR relates to [SS-925](https://scilifelab.atlassian.net/browse/SS-925).

Five app endpoints under `/projects/<project>/apps/` looked up the app id without checking that it belongs to the project in the URL. The permission check on those views only covers the URL slug, so any logged-in user with a project of their own could aim a request at that project and swap in an arbitrary app id to reach apps in projects they can't view.

Every lookup is now filtered on the project from the URL. An out-of-project id now behaves as if the app doesn't exist: 404 for logs, secrets and retry, 403 for delete, and left out of the status response.

## Checklist

- [x] This pull request is against **develop** branch (not applicable for hotfixes)
- [x] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [x] I have added or updated unit and end2end tests or a manual test case to complement my changes
- [ ] I have ran unit and end2end tests
- [x] I have considered accessibility for UI changes and reviewed pre-commit/Pa11y results or documented a manual check
- [ ] I have updated the related documentation (if necessary)
- [x] I have added a reviewer for this pull request
- [ ] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts
- [ ] In case your changes are large enough, did you deploy your changes to develop instance?