### PR TITLE
SS-780 bypass max proj limit

### DIFF
--- a/api/tests/test_api.py
+++ b/api/tests/test_api.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
+from django.test import override_settings
 from rest_framework import status
 from rest_framework.test import APITestCase
 
@@ -93,6 +94,21 @@ class ApiTests(APITestCase):
         url = os.path.join(self.BASE_API_URL, "content-review/")
         response = self.client.get(url, query_params={"token": "badToken"}, format="json")
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    @override_settings(PROJECTS_PER_USER_LIMIT=1)
+    @patch("api.views.create_resources_from_template.delay")
+    def test_create_project_returns_forbidden_when_limit_is_reached(self, mock_task):
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.post(
+            os.path.join(self.BASE_API_URL, "projects/"),
+            {"name": "over-limit", "description": "", "template": "unused"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.json(), {"detail": "User not allowed to create project"})
+        mock_task.assert_not_called()
 
     @patch("api.views.validate_static_token")
     def test_get_content_review(self, mock_validate_static_token):

--- a/api/views.py
+++ b/api/views.py
@@ -26,6 +26,7 @@ from rest_framework.decorators import (
     authentication_classes,
     permission_classes,
 )
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.mixins import (
     CreateModelMixin,
     ListModelMixin,
@@ -45,6 +46,7 @@ from apps.types_.subdomain import SubdomainCandidateName
 from doi_minting.clients.invenio_client import InvenioClient
 from models.models import ObjectType
 from portal.models import PublishedModel
+from projects.exceptions import ProjectLimitReachedException
 from projects.models import Environment, Flavor, ProjectLog, ProjectTemplate
 from projects.tasks import create_resources_from_template, delete_project_apps
 from studio.utils import get_logger
@@ -406,11 +408,14 @@ class ProjectList(
     def create(self, request):
         name = request.data["name"]
         description = request.data["description"]
-        project = Project.objects.create_project(
-            name=name,
-            owner=request.user,
-            description=description,
-        )
+        try:
+            project = Project.objects.create_project(
+                name=name,
+                owner=request.user,
+                description=description,
+            )
+        except ProjectLimitReachedException as exc:
+            raise PermissionDenied(str(exc)) from exc
         success = True
 
         try:

--- a/projects/exceptions.py
+++ b/projects/exceptions.py
@@ -2,5 +2,9 @@ class ProjectCreationException(Exception):
     pass
 
 
+class ProjectLimitReachedException(ProjectCreationException):
+    pass
+
+
 class ModelDeploymentCreationException(Exception):
     pass

--- a/projects/models.py
+++ b/projects/models.py
@@ -18,6 +18,8 @@ from guardian.shortcuts import assign_perm
 
 from studio.utils import get_logger
 
+from .exceptions import ProjectLimitReachedException
+
 logger = get_logger(__name__)
 
 
@@ -113,11 +115,6 @@ class Flavor(models.Model):
 # it will become the default objects attribute for a Project model
 class ProjectManager(models.Manager):
     def create_project(self, name, owner, description, status="active", project_template=None):
-        user_can_create = self.user_can_create(owner)
-
-        if not user_can_create:
-            raise Exception("User not allowed to create project")
-
         key = self.generate_passkey()
         letters = string.ascii_lowercase
         secret = self.generate_passkey(40)
@@ -127,18 +124,25 @@ class ProjectManager(models.Manager):
         slug_extension = "".join(random.choice(letters) for i in range(3))
         slug = "{}-{}".format(slugify(slug), slug_extension)
 
-        project = self.create(
-            name=name,
-            owner=owner,
-            slug=slug,
-            project_key=key,
-            project_secret=secret,
-            description=description,
-            status=status,
-            project_template=project_template,
-        )
+        with transaction.atomic():
+            locked_owner = get_user_model().objects.select_for_update().get(pk=owner.pk)
 
-        assign_perm("can_view_project", owner, project)
+            if not self.user_can_create(locked_owner):
+                raise ProjectLimitReachedException("User not allowed to create project")
+
+            project = self.create(
+                name=name,
+                owner=locked_owner,
+                slug=slug,
+                project_key=key,
+                project_secret=secret,
+                description=description,
+                status=status,
+                project_template=project_template,
+            )
+
+            assign_perm("can_view_project", locked_owner, project)
+
         return project
 
     def generate_passkey(self, length=20):
@@ -155,7 +159,7 @@ class ProjectManager(models.Manager):
         if not user.is_authenticated:
             return False
 
-        num_of_projects = self.filter(Q(owner=user), status="active").count()
+        num_of_projects = self.filter(Q(owner=user), status__in=("created", "active")).count()
 
         try:
             project_per_user_limit = settings.PROJECTS_PER_USER_LIMIT

--- a/projects/tests/test_project.py
+++ b/projects/tests/test_project.py
@@ -1,11 +1,16 @@
 import base64
+import concurrent.futures
+import threading
+from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
-from django.test import TestCase, override_settings
+from django.db import close_old_connections
+from django.test import TestCase, TransactionTestCase, override_settings
 
-from ..models import Flavor, Project
+from ..exceptions import ProjectLimitReachedException
+from ..models import Flavor, Project, ProjectManager
 
 User = get_user_model()
 
@@ -129,8 +134,31 @@ class ProjectTestCase(TestCase):
 
         _ = Project.objects.create(name="test-perm1", owner=user, description="")
 
-        with self.assertRaisesMessage(Exception, "User not allowed to create project"):
+        with self.assertRaisesMessage(ProjectLimitReachedException, "User not allowed to create project"):
             _ = Project.objects.create_project(name="test-perm", owner=user, description="")
+
+    @override_settings(PROJECTS_PER_USER_LIMIT=1)
+    def test_created_project_counts_towards_limit(self):
+        user = User.objects.get(username=test_member["email"])
+
+        Project.objects.create(
+            name="creating-project", slug="creating-project", owner=user, description="", status="created"
+        )
+
+        self.assertFalse(Project.objects.user_can_create(user))
+
+    @override_settings(PROJECTS_PER_USER_LIMIT=1)
+    def test_deleted_and_archived_projects_do_not_count_towards_limit(self):
+        user = User.objects.get(username=test_member["email"])
+
+        Project.objects.create(
+            name="deleted-project", slug="deleted-project", owner=user, description="", status="deleted"
+        )
+        Project.objects.create(
+            name="archived-project", slug="archived-project", owner=user, description="", status="archived"
+        )
+
+        self.assertTrue(Project.objects.user_can_create(user))
 
     @override_settings(PROJECTS_PER_USER_LIMIT=0)
     def test_admin_can_create(self):
@@ -153,3 +181,40 @@ class ProjectTestCase(TestCase):
         flavor_dict = self.flavor.to_dict(gpu_enabled_app=True)
         self.assertIn("nvidia.com/gpu", flavor_dict["flavor"]["requests"])
         self.assertIn("nvidia.com/gpu", flavor_dict["flavor"]["limits"])
+
+
+class ProjectCreationConcurrencyTestCase(TransactionTestCase):
+    def setUp(self):
+        self.user = User.objects.create_user("concurrent-user", "concurrent@test.com", "bar")
+
+    @override_settings(PROJECTS_PER_USER_LIMIT=2)
+    def test_concurrent_project_creation_cannot_exceed_limit(self):
+        Project.objects.create_project(name="existing-project", owner=self.user, description="")
+
+        barrier = threading.Barrier(2)
+        thread_state = threading.local()
+        original_generate_passkey = ProjectManager.generate_passkey
+
+        def synchronized_generate_passkey(manager, length=20):
+            if not getattr(thread_state, "synchronized", False):
+                thread_state.synchronized = True
+                barrier.wait(timeout=5)
+            return original_generate_passkey(manager, length)
+
+        def create_project(name):
+            close_old_connections()
+            try:
+                owner = User.objects.get(pk=self.user.pk)
+                project = Project.objects.create_project(name=name, owner=owner, description="")
+                return project.pk
+            except ProjectLimitReachedException:
+                return None
+            finally:
+                close_old_connections()
+
+        with patch.object(ProjectManager, "generate_passkey", synchronized_generate_passkey):
+            with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+                results = list(executor.map(create_project, ("concurrent-one", "concurrent-two")))
+
+        self.assertEqual(sum(project_pk is not None for project_pk in results), 1)
+        self.assertEqual(Project.objects.filter(owner=self.user, status__in=("created", "active")).count(), 2)

--- a/projects/tests/test_project_create_view.py
+++ b/projects/tests/test_project_create_view.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 
+from ..exceptions import ProjectLimitReachedException
 from ..models import ProjectTemplate
 
 User = get_user_model()
@@ -50,3 +51,23 @@ class ProjectCreateViewTestCase(TestCase):
             self.assertEqual(response.status_code, 302)
 
             mock_task.assert_called_once()
+
+    def test_project_create_post_returns_forbidden_if_limit_is_reached_during_creation(self):
+        with (
+            patch(
+                "projects.views.Project.objects.create_project",
+                side_effect=ProjectLimitReachedException("User not allowed to create project"),
+            ),
+            patch("projects.tasks.create_resources_from_template.delay") as mock_task,
+        ):
+            response = self.client.post(
+                "/projects/create/?template=Template",
+                {
+                    "name": "My Project",
+                    "description": "My description",
+                    "template_id": self.template_id,
+                },
+            )
+
+        self.assertEqual(response.status_code, 403)
+        mock_task.assert_not_called()

--- a/projects/views.py
+++ b/projects/views.py
@@ -29,7 +29,7 @@ from apps.helpers import get_cached_ip_count
 from apps.models import BaseAppInstance, VolumeInstance
 from common.tasks import send_email_task
 
-from .exceptions import ProjectCreationException
+from .exceptions import ProjectCreationException, ProjectLimitReachedException
 from .models import (
     Environment,
     Flavor,
@@ -608,9 +608,9 @@ class CreateProjectView(View):
                 status="created",
                 project_template=project_template,
             )
-        except ProjectCreationException:
-            logger.error("Failed to create project database object.")
-            success = False
+        except ProjectLimitReachedException:
+            logger.warning("Project limit reached while creating project for user %s.", request.user.pk)
+            return HttpResponseForbidden()
 
         try:
             # Create resources from the chosen template


### PR DESCRIPTION
## Description

This PR relates to [SS-780](https://scilifelab.atlassian.net/browse/SS-780).

Project creation now locks the owner’s database row and rechecks the project limit inside the same transaction. This prevents concurrent requests from both passing the limit check.

- Counts projects being provisioned (`created`) as well as `active` projects toward the limit.
- Returns `403 Forbidden` from the browser and API flows when another request consumes the final slot.
- Adds coverage for concurrent creation, project statuses, and browser/API error handling.

## Checklist

- [x] This pull request is against **develop** branch (not applicable for hotfixes)
- [x] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [x] I have added or updated unit and end2end tests or a manual test case to complement my changes
- [ ] I have ran unit and end2end tests
- [x] I have considered accessibility for UI changes and reviewed pre-commit/Pa11y results or documented a manual check
- [x] I have updated the related documentation (if necessary)
- [x] I have added a reviewer for this pull request
- [x] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts
- [ ] In case your changes are large enough, did you deploy your changes to develop instance?