### PR TITLE
SS-1124 fix admin redeploy

### DIFF
--- a/apps/admin.py
+++ b/apps/admin.py
@@ -139,7 +139,7 @@ class BaseAppAdmin(admin.ModelAdmin):
 
     display_volumes.short_description = "Volumes"
 
-    @admin.action(description="Redeploy apps")
+    @admin.action(description="(Re)deploy resources")
     def deploy_resources(self, request, queryset):
         scheduled_count = 0
 

--- a/apps/admin.py
+++ b/apps/admin.py
@@ -1,4 +1,3 @@
-import time
 from datetime import datetime
 
 from django.contrib import admin, messages
@@ -10,7 +9,12 @@ from apps.constants import AppActionOrigin
 from projects.models import PersistentVolumeMountPath
 from studio.utils import get_logger
 
-from .helpers import export_k8s_values_to_yaml, get_URI, set_linkonly_reminder_date
+from .helpers import (
+    export_k8s_values_to_yaml,
+    get_URI,
+    reset_k8s_user_app_status_for_deployment,
+    set_linkonly_reminder_date,
+)
 from .models import (
     AppCategories,
     Apps,
@@ -91,7 +95,6 @@ class BaseAppAdmin(admin.ModelAdmin):
     readonly_fields = ("id", "created_on", "updated_on")
     list_filter = ["owner", "project", "k8s_user_app_status__status", "chart"]
     actions = [
-        "redeploy_apps",
         "deploy_resources",
         "delete_resources",
         "export_values_yaml",
@@ -136,33 +139,25 @@ class BaseAppAdmin(admin.ModelAdmin):
 
     display_volumes.short_description = "Volumes"
 
-    @admin.action(description="(Re)deploy resources")
+    @admin.action(description="Redeploy apps")
     def deploy_resources(self, request, queryset):
-        success_count = 0
-        failure_count = 0
+        scheduled_count = 0
 
         for instance in queryset:
             instance.set_k8s_values()
             instance.url = get_URI(instance)
-            instance.save(update_fields=["k8s_values", "url"])
+            instance.latest_user_action = "Changing"
+            instance.save(update_fields=["k8s_values", "url", "latest_user_action"])
+            reset_k8s_user_app_status_for_deployment(instance)
 
-            deploy_resource.delay(instance.serialize())
-            time.sleep(2)
-            info_dict = instance.info
-            if info_dict:
-                success = info_dict["helm"].get("success", False)
-                if success:
-                    success_count += 1
-                else:
-                    failure_count += 1
-            else:
-                failure_count += 1
+            deploy_resource.delay(instance.serialize(), force_redeploy=True)
+            scheduled_count += 1
 
-        if success_count:
-            self.message_user(request, f"{success_count} apps successfully (re)deployed.", messages.SUCCESS)
-        if failure_count:
+        if scheduled_count:
             self.message_user(
-                request, f"Failed to redeploy {failure_count} apps. Check logs for details.", messages.ERROR
+                request,
+                f"Scheduled {scheduled_count} apps for redeployment.",
+                messages.SUCCESS,
             )
 
     @admin.action(description="Delete resources")

--- a/apps/tasks.py
+++ b/apps/tasks.py
@@ -295,7 +295,7 @@ def get_manifest_yaml(release_name: str, namespace: str = "default") -> tuple[st
         return e.stdout, e.stderr
 
 
-def restart_helm_workloads(release_name: str, namespace: str = "default") -> tuple[str | None, str | None]:
+def _kubectl_rollout_restart(release_name: str, namespace: str = "default") -> tuple[str | None, str | None]:
     """Restart the rollout-capable workloads managed by a Helm release."""
     manifest, error = get_manifest_yaml(release_name, namespace)
     if error:
@@ -506,7 +506,7 @@ def deploy_resource(self, serialized_instance, force_redeploy: bool = False):
     restart_output = None
     restart_error = None
     if success and force_redeploy:
-        restart_output, restart_error = restart_helm_workloads(release, values["namespace"])
+        restart_output, restart_error = _kubectl_rollout_restart(release, values["namespace"])
         success = not restart_error
         logger.info(
             "deploy_resource.rollout_restart_done task_id=%s instance_id=%s success=%s release=%s stderr=%s",

--- a/apps/tasks.py
+++ b/apps/tasks.py
@@ -295,18 +295,52 @@ def get_manifest_yaml(release_name: str, namespace: str = "default") -> tuple[st
         return e.stdout, e.stderr
 
 
+def restart_helm_workloads(release_name: str, namespace: str = "default") -> tuple[str | None, str | None]:
+    """Restart the rollout-capable workloads managed by a Helm release."""
+    manifest, error = get_manifest_yaml(release_name, namespace)
+    if error:
+        return manifest, error
+
+    try:
+        documents = yaml.safe_load_all(manifest or "")
+        restartable_kinds = {"Deployment", "StatefulSet", "DaemonSet"}
+        resources = []
+        for document in documents:
+            if not isinstance(document, dict) or document.get("kind") not in restartable_kinds:
+                continue
+
+            metadata = document.get("metadata")
+            name = metadata.get("name") if isinstance(metadata, dict) else None
+            if name:
+                resources.append(f"{document['kind'].lower()}/{name}")
+    except yaml.YAMLError as exc:
+        return None, f"Failed to parse Helm manifest for release {release_name}: {exc}"
+
+    resources = list(dict.fromkeys(resources))
+    if not resources:
+        return f"No restartable workloads found for Helm release {release_name}.", None
+
+    command = ["kubectl", "rollout", "restart", *resources, "--namespace", namespace]
+    try:
+        result = subprocess.run(command, check=True, text=True, capture_output=True)
+        return result.stdout, None
+    except subprocess.CalledProcessError as exc:
+        return exc.stdout, exc.stderr
+
+
 @shared_task(bind=True, max_retries=DEPLOY_RESOURCE_MAX_RETRIES)
-def deploy_resource(self, serialized_instance):
+def deploy_resource(self, serialized_instance, force_redeploy: bool = False):
     model = serialized_instance.get("model") if isinstance(serialized_instance, dict) else None
     pk = serialized_instance.get("pk") if isinstance(serialized_instance, dict) else None
     task_id = getattr(self.request, "id", None)
 
     logger.info(
-        "deploy_resource.start task_id=%s model=%s pk=%s retry=%s",
+        "deploy_resource.start task_id=%s model=%s pk=%s retry=%s force_redeploy=%s",
         task_id,
         model,
         pk,
         self.request.retries,
+        force_redeploy,
     )
 
     try:
@@ -469,11 +503,42 @@ def deploy_resource(self, serialized_instance):
         release,
     )
 
+    restart_output = None
+    restart_error = None
+    if success and force_redeploy:
+        restart_output, restart_error = restart_helm_workloads(release, values["namespace"])
+        success = not restart_error
+        logger.info(
+            "deploy_resource.rollout_restart_done task_id=%s instance_id=%s success=%s release=%s stderr=%s",
+            task_id,
+            instance.pk,
+            success,
+            release,
+            restart_error,
+        )
+
+        if restart_error and self.request.retries < self.max_retries:
+            countdown = _retry_countdown(self.request.retries)
+            logger.warning(
+                "deploy_resource.rollout_restart_retry task_id=%s instance_id=%s retry=%s/%s countdown=%ss",
+                task_id,
+                instance.pk,
+                self.request.retries + 1,
+                self.max_retries,
+                countdown,
+            )
+            raise self.retry(exc=RuntimeError(restart_error), countdown=countdown)
+
+    if restart_error:
+        error = restart_error
+
     helm_info = {
         "success": success,
         "info": {"stdout": output, "stderr": error},
         "completed_at": timezone.now().isoformat(),
     }
+    if force_redeploy:
+        helm_info["restart"] = {"stdout": restart_output, "stderr": restart_error}
 
     instance.info = dict(helm=helm_info)
     # instance.app_status.status = "Created" if success else "Failed"

--- a/apps/tests/test_admin_redeploy.py
+++ b/apps/tests/test_admin_redeploy.py
@@ -8,7 +8,7 @@ from django.urls import reverse
 from apps.admin import BaseAppAdmin
 from apps.models import Apps, DashInstance, K8sUserAppStatus, Subdomain
 from apps.tasks import deploy_resource, restart_helm_workloads
-from projects.models import Project
+from projects.models import Flavor, Project
 
 User = get_user_model()
 
@@ -97,9 +97,7 @@ class RedeployAppsAdminActionTestCase(TestCase):
 
 class CreateLinkOnlyAppInAdminTestCase(TestCase):
     def setUp(self):
-        self.superuser = User.objects.create_superuser(
-            "link-admin", "link-admin@example.com", "password"
-        )
+        self.superuser = User.objects.create_superuser("link-admin", "link-admin@example.com", "password")
         self.project = Project.objects.create_project(name="link-admin", owner=self.superuser, description="")
         self.app = Apps.objects.create(name="Dash", slug="dashapp", chart="dash-chart:1.0.0")
         self.subdomain = Subdomain.objects.create(subdomain="link-admin-app", project=self.project)
@@ -123,6 +121,7 @@ class CreateLinkOnlyAppInAdminTestCase(TestCase):
                 "subdomain": self.subdomain.pk,
                 "subjects_keywords": "[]",
                 "tags": "",
+                "upload_size": 100,
                 "_save": "Save",
             },
         )
@@ -131,6 +130,41 @@ class CreateLinkOnlyAppInAdminTestCase(TestCase):
         instance = DashInstance.objects.get(name="Admin-created link app")
         self.assertEqual(instance.access, "link")
         self.assertEqual(instance.note_on_linkonly_privacy, "Shared with reviewers")
+
+
+class CreateLinkOnlyAppInProductUITestCase(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user("link-user", "link-user@example.com", "password")
+        self.project = Project.objects.create_project(name="link-ui", owner=self.user, description="")
+        self.flavor = Flavor.objects.create(name="Small", project=self.project)
+        self.app = Apps.objects.create(name="Dash", slug="dashapp", chart="dash-chart:1.0.0")
+        self.client.force_login(self.user)
+
+    @patch("apps.tasks.run_background_tasks.delay")
+    def test_user_can_create_link_only_app(self, mock_background_tasks):
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(
+                reverse("apps:create", kwargs={"project": self.project.slug, "app_slug": self.app.slug}),
+                {
+                    "access": "link",
+                    "description": "Link-only app created through the product UI",
+                    "flavor": self.flavor.pk,
+                    "image": "example.org/dash:latest",
+                    "invenio_tags": "",
+                    "name": "UI-created link app",
+                    "note_on_linkonly_privacy": "Shared with reviewers",
+                    "port": 8050,
+                    "source_code_url": "",
+                    "subdomain": "link-ui-app",
+                },
+            )
+
+        self.assertEqual(response.status_code, 302)
+        instance = DashInstance.objects.get(name="UI-created link app")
+        self.assertEqual(instance.access, "link")
+        self.assertEqual(instance.note_on_linkonly_privacy, "Shared with reviewers")
+        self.assertIsNotNone(instance.reminder_date_linkonly_privacy)
+        mock_background_tasks.assert_called_once()
 
 
 class RestartHelmWorkloadsTestCase(SimpleTestCase):

--- a/apps/tests/test_admin_redeploy.py
+++ b/apps/tests/test_admin_redeploy.py
@@ -7,7 +7,7 @@ from django.urls import reverse
 
 from apps.admin import BaseAppAdmin
 from apps.models import Apps, DashInstance, K8sUserAppStatus, Subdomain
-from apps.tasks import deploy_resource, restart_helm_workloads
+from apps.tasks import _kubectl_rollout_restart, deploy_resource
 from projects.models import Flavor, Project
 
 User = get_user_model()
@@ -68,7 +68,7 @@ class RedeployAppsAdminActionTestCase(TestCase):
         self.assertTrue(mock_deploy.call_args.kwargs["force_redeploy"])
 
     @override_settings(DEBUG=False)
-    @patch("apps.tasks.restart_helm_workloads", return_value=("restarted", None))
+    @patch("apps.tasks._kubectl_rollout_restart", return_value=("restarted", None))
     @patch("apps.tasks.helm_install", return_value=("upgraded", None))
     def test_force_redeploy_restarts_workloads_after_helm_upgrade(self, _mock_helm, mock_restart):
         self.instance.set_k8s_values()
@@ -82,7 +82,7 @@ class RedeployAppsAdminActionTestCase(TestCase):
         self.assertEqual(self.instance.info["helm"]["restart"]["stdout"], "restarted")
 
     @override_settings(DEBUG=False)
-    @patch("apps.tasks.restart_helm_workloads")
+    @patch("apps.tasks._kubectl_rollout_restart")
     @patch("apps.tasks.helm_install", return_value=("upgraded", None))
     def test_regular_deploy_does_not_force_workload_restart(self, _mock_helm, mock_restart):
         self.instance.set_k8s_values()
@@ -193,7 +193,7 @@ metadata:
         )
         mock_run.return_value.stdout = "restarted"
 
-        output, error = restart_helm_workloads("release", "namespace")
+        output, error = _kubectl_rollout_restart("release", "namespace")
 
         self.assertEqual(output, "restarted")
         self.assertIsNone(error)
@@ -215,7 +215,7 @@ metadata:
     @patch("apps.tasks.subprocess.run")
     @patch("apps.tasks.get_manifest_yaml", return_value=("kind: PersistentVolumeClaim", None))
     def test_release_without_workloads_does_not_call_kubectl(self, _mock_manifest, mock_run):
-        output, error = restart_helm_workloads("release", "namespace")
+        output, error = _kubectl_rollout_restart("release", "namespace")
 
         self.assertEqual(output, "No restartable workloads found for Helm release release.")
         self.assertIsNone(error)

--- a/apps/tests/test_admin_redeploy.py
+++ b/apps/tests/test_admin_redeploy.py
@@ -1,0 +1,188 @@
+from unittest.mock import patch
+
+from django.contrib import admin
+from django.contrib.auth import get_user_model
+from django.test import RequestFactory, SimpleTestCase, TestCase, override_settings
+from django.urls import reverse
+
+from apps.admin import BaseAppAdmin
+from apps.models import Apps, DashInstance, K8sUserAppStatus, Subdomain
+from apps.tasks import deploy_resource, restart_helm_workloads
+from projects.models import Project
+
+User = get_user_model()
+
+
+class RedeployAppsAdminActionTestCase(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user("admin-redeploy", "admin-redeploy@example.com", "password")
+        self.project = Project.objects.create_project(name="admin-redeploy", owner=self.user, description="")
+        self.app = Apps.objects.create(name="Dash", slug="dashapp", chart="dash-chart:1.0.0")
+        self.subdomain = Subdomain.objects.create(subdomain="admin-redeploy", project=self.project)
+        self.status = K8sUserAppStatus.objects.create(status="Running")
+        self.instance = DashInstance.objects.create(
+            access="public",
+            app=self.app,
+            chart=self.app.chart,
+            image="example.org/dash:latest",
+            info={"helm": {"success": True}},
+            k8s_user_app_status=self.status,
+            latest_user_action="Creating",
+            name="Admin redeploy",
+            owner=self.user,
+            port=8050,
+            project=self.project,
+            subdomain=self.subdomain,
+        )
+        self.model_admin = BaseAppAdmin(DashInstance, admin.site)
+        self.request = RequestFactory().post("/admin/apps/dashinstance/")
+
+    @patch("apps.admin.deploy_resource.delay")
+    def test_redeploy_forces_rollout_and_resets_deployment_status(self, mock_deploy):
+        with patch.object(self.model_admin, "message_user"):
+            self.model_admin.deploy_resources(self.request, DashInstance.objects.filter(pk=self.instance.pk))
+
+        self.instance.refresh_from_db()
+        self.status.refresh_from_db()
+
+        self.assertEqual(self.instance.latest_user_action, "Changing")
+        self.assertIsNone(self.status.status)
+        self.assertNotIn("helm", self.instance.info)
+        mock_deploy.assert_called_once()
+        self.assertTrue(mock_deploy.call_args.kwargs["force_redeploy"])
+
+    @patch("apps.admin.deploy_resource.delay")
+    def test_redeploy_link_only_app(self, mock_deploy):
+        self.instance.access = "link"
+        self.instance.note_on_linkonly_privacy = "Shared with reviewers"
+        self.instance.save(update_fields=["access", "note_on_linkonly_privacy"])
+
+        with patch.object(self.model_admin, "message_user"):
+            self.model_admin.deploy_resources(self.request, DashInstance.objects.filter(pk=self.instance.pk))
+
+        self.instance.refresh_from_db()
+        self.assertEqual(self.instance.access, "link")
+        self.assertEqual(self.instance.k8s_values["permission"], "link")
+        self.assertEqual(self.instance.latest_user_action, "Changing")
+        mock_deploy.assert_called_once()
+        self.assertTrue(mock_deploy.call_args.kwargs["force_redeploy"])
+
+    @override_settings(DEBUG=False)
+    @patch("apps.tasks.restart_helm_workloads", return_value=("restarted", None))
+    @patch("apps.tasks.helm_install", return_value=("upgraded", None))
+    def test_force_redeploy_restarts_workloads_after_helm_upgrade(self, _mock_helm, mock_restart):
+        self.instance.set_k8s_values()
+        self.instance.save(update_fields=["k8s_values"])
+
+        deploy_resource.run(self.instance.serialize(), force_redeploy=True)
+
+        mock_restart.assert_called_once_with(self.subdomain.subdomain, self.instance.k8s_values["namespace"])
+        self.instance.refresh_from_db()
+        self.assertTrue(self.instance.info["helm"]["success"])
+        self.assertEqual(self.instance.info["helm"]["restart"]["stdout"], "restarted")
+
+    @override_settings(DEBUG=False)
+    @patch("apps.tasks.restart_helm_workloads")
+    @patch("apps.tasks.helm_install", return_value=("upgraded", None))
+    def test_regular_deploy_does_not_force_workload_restart(self, _mock_helm, mock_restart):
+        self.instance.set_k8s_values()
+        self.instance.save(update_fields=["k8s_values"])
+
+        deploy_resource.run(self.instance.serialize())
+
+        mock_restart.assert_not_called()
+        self.instance.refresh_from_db()
+        self.assertNotIn("restart", self.instance.info["helm"])
+
+
+class CreateLinkOnlyAppInAdminTestCase(TestCase):
+    def setUp(self):
+        self.superuser = User.objects.create_superuser(
+            "link-admin", "link-admin@example.com", "password"
+        )
+        self.project = Project.objects.create_project(name="link-admin", owner=self.superuser, description="")
+        self.app = Apps.objects.create(name="Dash", slug="dashapp", chart="dash-chart:1.0.0")
+        self.subdomain = Subdomain.objects.create(subdomain="link-admin-app", project=self.project)
+        self.client.force_login(self.superuser)
+
+    def test_admin_can_create_link_only_app(self):
+        response = self.client.post(
+            reverse("admin:apps_dashinstance_add"),
+            {
+                "access": "link",
+                "app": self.app.pk,
+                "chart": self.app.chart,
+                "description": "Link-only app created by an administrator",
+                "image": "example.org/dash:latest",
+                "latest_user_action": "Creating",
+                "name": "Admin-created link app",
+                "note_on_linkonly_privacy": "Shared with reviewers",
+                "owner": self.superuser.pk,
+                "port": 8050,
+                "project": self.project.pk,
+                "subdomain": self.subdomain.pk,
+                "subjects_keywords": "[]",
+                "tags": "",
+                "_save": "Save",
+            },
+        )
+
+        self.assertEqual(response.status_code, 302, response.context and response.context["adminform"].form.errors)
+        instance = DashInstance.objects.get(name="Admin-created link app")
+        self.assertEqual(instance.access, "link")
+        self.assertEqual(instance.note_on_linkonly_privacy, "Shared with reviewers")
+
+
+class RestartHelmWorkloadsTestCase(SimpleTestCase):
+    @patch("apps.tasks.subprocess.run")
+    @patch("apps.tasks.get_manifest_yaml")
+    def test_restarts_every_rollout_capable_workload(self, mock_manifest, mock_run):
+        mock_manifest.return_value = (
+            """
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: worker
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+""",
+            None,
+        )
+        mock_run.return_value.stdout = "restarted"
+
+        output, error = restart_helm_workloads("release", "namespace")
+
+        self.assertEqual(output, "restarted")
+        self.assertIsNone(error)
+        mock_run.assert_called_once_with(
+            [
+                "kubectl",
+                "rollout",
+                "restart",
+                "deployment/web",
+                "statefulset/worker",
+                "--namespace",
+                "namespace",
+            ],
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+
+    @patch("apps.tasks.subprocess.run")
+    @patch("apps.tasks.get_manifest_yaml", return_value=("kind: PersistentVolumeClaim", None))
+    def test_release_without_workloads_does_not_call_kubectl(self, _mock_manifest, mock_run):
+        output, error = restart_helm_workloads("release", "namespace")
+
+        self.assertEqual(output, "No restartable workloads found for Helm release release.")
+        self.assertIsNone(error)
+        mock_run.assert_not_called()


### PR DESCRIPTION
## Description

This PR relates to [SS-1124](https://scilifelab.atlassian.net/browse/SS-1124).

The admin **Redeploy resources** action now performs an actual workload restart after the Helm upgrade. Before this change, a Helm upgrade with no changes could leave the existing pods untouched and the app in an incorrect or stale status.

- Sets the app action to `Changing` and clears stale deployment status before scheduling the redeployment.
- Adds a forced-redeploy option to the existing deployment task.
- Restarts the Deployments, StatefulSets, and DaemonSets found in the Helm release manifest.
- Retries failed rollout restarts using the existing deployment retry behavior.

## Checklist

- [x] This pull request is against **develop** branch (not applicable for hotfixes)
- [x] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [x] I have added or updated unit and end2end tests or a manual test case to complement my changes
- [ ] I have ran unit and end2end tests
- [x] I have considered accessibility for UI changes and reviewed pre-commit/Pa11y results or documented a manual check
- [ ] I have updated the related documentation (if necessary)
- [x] I have added a reviewer for this pull request
- [x] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts 
- [ ] In case your changes are large enough, did you deploy your changes to develop instance?