### PR TITLE
SS-1433 subdomain reuse collision

### DIFF
--- a/apps/helpers.py
+++ b/apps/helpers.py
@@ -477,9 +477,11 @@ def create_instance_from_form(
 
     instance = form.save(commit=False)
 
-    # Retrieve or create the subdomain
+    # Retrieve or create the subdomain. Look up on the unique field only, so an existing
+    # row with a different project or is_created_by_user is reused, not inserted again.
     subdomain, created = Subdomain.objects.get_or_create(
-        subdomain=subdomain_name, project=project, is_created_by_user=is_created_by_user
+        subdomain=subdomain_name,
+        defaults={"project": project, "is_created_by_user": is_created_by_user},
     )
     assert subdomain is not None
     assert subdomain.subdomain == subdomain_name

--- a/apps/helpers.py
+++ b/apps/helpers.py
@@ -730,11 +730,57 @@ def get_or_create_status(instance, app_id):
     # return instance.app_status if app_id else AppStatus.objects.create()
 
 
+def _old_release_is_removed(delete_result: Any) -> bool:
+    """
+    Whether delete_resource confirmed that nothing is left in the cluster.
+
+    Without a confirmed result the old release must be assumed to be running.
+    """
+    if not isinstance(delete_result, dict):
+        return False
+
+    return bool(delete_result.get("success")) or bool(delete_result.get("release_missing"))
+
+
+SUBDOMAIN_RELEASE_EXCLUDED_APP_SLUGS = ("volumeK8s", "netpolicy")
+
+
+def release_subdomain_after_delete(instance: BaseAppInstance) -> Optional[Subdomain]:
+    """
+    Detach a deleted app from its subdomain so that the name becomes available again.
+
+    Only user-chosen names are reclaimed, and volumes are excluded because the apps that
+    mount them still read their subdomain.
+
+    Must only be called once the release is confirmed gone from the cluster, otherwise the
+    name becomes available while its resources are still running.
+
+    Returns the detached subdomain, or None if nothing was released. The caller is
+    responsible for saving the instance.
+    """
+    subdomain = instance.subdomain
+
+    if subdomain is None or not subdomain.is_created_by_user:
+        return None
+
+    if instance.app.slug in SUBDOMAIN_RELEASE_EXCLUDED_APP_SLUGS:
+        return None
+
+    instance.subdomain = None
+    return subdomain
+
+
 def handle_subdomain_change(instance: Any, subdomain: str, subdomain_name: str) -> None:
     """
     Detects if there has been a user-initiated subdomain change and if so,
     then re-creates the app instance, also re-deploying the k8s resource.
+
+    Raises:
+    - SubdomainChangeError: if the app's current release could not be removed from the
+      cluster. The subdomain is then left unchanged.
     """
+    from apps.types_.subdomain import SubdomainChangeError
+
     from .tasks import delete_resource
 
     assert instance is not None, "instance is required"
@@ -753,7 +799,19 @@ def handle_subdomain_change(instance: Any, subdomain: str, subdomain_name: str) 
     if instance.subdomain.subdomain != subdomain_name:
         # The user modified the subdomain name
         # In this special case, we avoid async task.
-        delete_resource(instance.serialize(), AppActionOrigin.USER.value)
+        delete_result = delete_resource(instance.serialize(), AppActionOrigin.USER.value)
+
+        if not _old_release_is_removed(delete_result):
+            logger.error(
+                "handle_subdomain_change.aborted_release_not_removed instance_id=%s "
+                "old_subdomain=%s requested_subdomain=%s error=%s",
+                instance.pk,
+                instance.subdomain.subdomain,
+                subdomain_name,
+                delete_result.get("error") if isinstance(delete_result, dict) else None,
+            )
+            raise SubdomainChangeError()
+
         old_subdomain = instance.subdomain
         instance.subdomain = subdomain
         instance.save(update_fields=["subdomain"])

--- a/apps/models/app_types/depictio.py
+++ b/apps/models/app_types/depictio.py
@@ -23,8 +23,9 @@ class DepictioInstance(BaseAppInstance, SocialMixin):
 
     def get_k8s_values(self):
         k8s_values = super().get_k8s_values()
+        release_name = self.subdomain.subdomain if self.subdomain else "deleted"
         k8s_values["commonLabels"] = {
-            "release": self.subdomain.subdomain,
+            "release": release_name,
             "app": "depictio",
             "project": self.project.slug,
         }
@@ -64,7 +65,7 @@ class DepictioInstance(BaseAppInstance, SocialMixin):
                                 f"location = /_depictio_auth {{\n"
                                 f"    internal;\n"
                                 f"    client_max_body_size {self.upload_size}M;\n"
-                                f"    proxy_pass {settings.AUTH_PROTOCOL}://{settings.AUTH_DOMAIN}:8080/auth/?release={self.subdomain.subdomain};\n"
+                                f"    proxy_pass {settings.AUTH_PROTOCOL}://{settings.AUTH_DOMAIN}:8080/auth/?release={release_name};\n"
                                 f"    proxy_pass_request_body off;\n"
                                 f'    proxy_set_header Content-Length "";\n'
                                 f"    proxy_set_header X-Original-URI $request_uri;\n"
@@ -82,7 +83,7 @@ class DepictioInstance(BaseAppInstance, SocialMixin):
             if self.access in ("private", "project"):
                 k8s_values["ingress"]["annotations"] = {
                     **base_annotations,
-                    "nginx.ingress.kubernetes.io/auth-url": f"{settings.AUTH_PROTOCOL}://{settings.AUTH_DOMAIN}:8080/auth/?release={self.subdomain.subdomain}",
+                    "nginx.ingress.kubernetes.io/auth-url": f"{settings.AUTH_PROTOCOL}://{settings.AUTH_DOMAIN}:8080/auth/?release={release_name}",
                     "nginx.ingress.kubernetes.io/auth-signin": f"https://{settings.DOMAIN}/accounts/login/",
                     "nginx.ingress.kubernetes.io/auth-signin-redirect-param": "next",
                 }

--- a/apps/models/app_types/mlflow.py
+++ b/apps/models/app_types/mlflow.py
@@ -26,7 +26,7 @@ class MLFlowInstance(BaseAppInstance):
     def get_k8s_values(self):
         k8s_values = super().get_k8s_values()
         k8s_values["commonLabels"] = {
-            "release": self.subdomain.subdomain,
+            "release": self.subdomain.subdomain if self.subdomain else "deleted",
             "app": "mlflow",
             "project": self.project.slug,
         }

--- a/apps/tasks.py
+++ b/apps/tasks.py
@@ -18,7 +18,11 @@ from apps.app_registry import APP_REGISTRY
 from apps.background_tasks.utils import select_latest_task_records
 from apps.constants import AppActionOrigin
 from apps.gpu import instance_holds_gpu
-from apps.helpers import generate_helm_install_command, get_merged_k8s_values
+from apps.helpers import (
+    generate_helm_install_command,
+    get_merged_k8s_values,
+    release_subdomain_after_delete,
+)
 from common.tasks import send_email_task
 from studio.celery import app
 from studio.utils import get_logger
@@ -31,6 +35,8 @@ CHART_REGEX = re.compile(r"^(?P<chart>.+):(?P<version>.+)$")
 DEPLOY_RESOURCE_MAX_RETRIES = 3
 DEPLOY_RESOURCE_RETRY_BASE_SECONDS = 10
 DEPLOY_RESOURCE_RETRY_MAX_SECONDS = 30
+
+HELM_RELEASE_NOT_FOUND_MARKERS = ("release: not found", "release not loaded")
 
 
 class MissingSerializedInstanceError(ValueError):
@@ -85,6 +91,15 @@ def _retry_countdown(current_retries: int) -> int:
     return min(DEPLOY_RESOURCE_RETRY_BASE_SECONDS * (2**current_retries), DEPLOY_RESOURCE_RETRY_MAX_SECONDS)
 
 
+def _is_helm_release_not_found(error: str | None) -> bool:
+    """Whether a helm error only means that the release does not exist."""
+    if not error:
+        return False
+
+    lowered = error.lower()
+    return any(marker in lowered for marker in HELM_RELEASE_NOT_FOUND_MARKERS)
+
+
 @app.task
 def delete_old_objects():
     """
@@ -120,7 +135,7 @@ def delete_old_objects():
         app_.save(update_fields=["latest_user_action", "deleted_on"])
 
         try:
-            delete_resource.delay(serialized_instance, AppActionOrigin.SYSTEM.value)
+            delete_resource.delay(serialized_instance, AppActionOrigin.SYSTEM.value, release_subdomain=True)
         except Exception:
             app_.latest_user_action = previous_latest_user_action
             app_.deleted_on = previous_deleted_on
@@ -590,7 +605,7 @@ def deploy_resource(self, serialized_instance, force_redeploy: bool = False):
 
 
 @shared_task
-def delete_resource(serialized_instance, initiated_by_str: str):
+def delete_resource(serialized_instance, initiated_by_str: str, release_subdomain: bool = False):
     """
     Deletes a cluster resource object.
     For deletes that are initiated by the system itself (such as recurring tasks),
@@ -602,6 +617,9 @@ def delete_resource(serialized_instance, initiated_by_str: str):
     Parameters:
     - serialized_instance: A serialized version of the app to be deleted.
     - initiated_by_str: A string of enum AppActionOrigin indicating the source of the deletion (user|system).
+    - release_subdomain: Set by app deletions so the subdomain becomes available again once
+      the release is confirmed gone. Left False by the subdomain change flow, which assigns
+      the new subdomain itself.
     """
     logger.info(
         "delete_resource.start model=%s pk=%s initiated_by=%s payload_type=%s",
@@ -625,9 +643,11 @@ def delete_resource(serialized_instance, initiated_by_str: str):
         connection.close()
 
     success = False
+    release_missing = False
     if values.get("subdomain") is not None:
         output, error = helm_delete(values["subdomain"], values["namespace"])
         success = not error
+        release_missing = bool(error) and _is_helm_release_not_found(error)
     else:
         error_text = f"Subdomain name does not exist. App: {values['name']}, Project: {values['project']['slug']}"
         output, error = error_text, error_text
@@ -656,9 +676,30 @@ def delete_resource(serialized_instance, initiated_by_str: str):
         # This is a common scenario for "apps" such as volumeK8s, netpolicy, notebooks and file managers.
         instance.latest_user_action = "SystemDeleting"
         instance.deleted_on = timezone.now()
-        instance.save(update_fields=["latest_user_action", "deleted_on", "info"])
+        update_fields = ["latest_user_action", "deleted_on", "info"]
     else:
-        instance.save(update_fields=["info"])
+        update_fields = ["info"]
+
+    released_subdomain = None
+    if release_subdomain and (success or release_missing):
+        released_subdomain = release_subdomain_after_delete(instance)
+        if released_subdomain is not None:
+            update_fields.append("subdomain")
+
+    instance.save(update_fields=update_fields)
+
+    if released_subdomain is not None:
+        logger.info(
+            "delete_resource.subdomain_released instance_id=%s subdomain=%s",
+            instance.pk,
+            released_subdomain.subdomain,
+        )
+
+    return {
+        "success": success,
+        "release_missing": release_missing,
+        "error": None if success else error,
+    }
 
 
 def deserialize(serialized_instance):

--- a/apps/tests/test_app_helper_utils.py
+++ b/apps/tests/test_app_helper_utils.py
@@ -26,9 +26,38 @@ from doi_minting.services.schemas import InvenioRecord
 from projects.models import Flavor, Project
 
 from ..models import Apps, DashInstance, K8sUserAppStatus, Subdomain
-from ..types_.subdomain import SubdomainTuple
+from ..tasks import _is_helm_release_not_found
+from ..types_.subdomain import SubdomainChangeError, SubdomainTuple
+
+DELETE_RESOURCE_OK = {"success": True, "release_missing": False, "error": None}
 
 User = get_user_model()
+
+
+class HelmReleaseNotFoundTestCase(TestCase):
+    """Tests for classifying helm uninstall errors."""
+
+    def test_missing_release_errors_are_recognised(self):
+        errors = [
+            "Error: uninstall: Release not loaded: my-app: release: not found",
+            "Error: release: not found",
+            "ERROR: UNINSTALL: RELEASE NOT LOADED: MY-APP",
+        ]
+        for error in errors:
+            with self.subTest(error=error):
+                self.assertTrue(_is_helm_release_not_found(error))
+
+    def test_real_failures_are_not_treated_as_missing_release(self):
+        errors = [
+            "Error: uninstall: timed out waiting for the condition",
+            "Error: failed to delete release: my-app",
+            'Error: pre-delete hook failed: job "delete-user-pods-my-app" failed: BackoffLimitExceeded',
+            "",
+            None,
+        ]
+        for error in errors:
+            with self.subTest(error=error):
+                self.assertFalse(_is_helm_release_not_found(error))
 
 
 class CreateAppInstanceTestCase(TestCase):
@@ -272,6 +301,8 @@ class UpdateExistingAppInstanceTestCase(TestCase):
 
         changed_fields = ["subdomain", "invenio_tags", "creators"]
 
+        mock_delete.return_value = DELETE_RESOURCE_OK
+
         # Apply the form and validate the result
         self._verify_update_instance_from_form(data, changed_fields)
 
@@ -279,6 +310,79 @@ class UpdateExistingAppInstanceTestCase(TestCase):
         mock_deploy.assert_called_once()
         # Modifying the subdomain SHOULD cause a delete:
         mock_delete.assert_called_once_with(ANY, AppActionOrigin.USER.value)
+
+    def _subdomain_change_form(self, new_subdomain: str):
+        """Build a valid form that only changes the app subdomain."""
+        data = {
+            "name": self.name,
+            "description": self.description,
+            "access": "public",
+            "port": self.port,
+            "image": self.image,
+            "source_code_url": self.source_code_url,
+            "subdomain": new_subdomain,
+            "invenio_tags": "Antibodies|Cells",
+            "creators": '[{"name": "Test", "lastName": "User", "affiliation": "", "orcid": "", "order": 0}]',
+        }
+
+        model_class, form_class = APP_REGISTRY.get(self.app_slug)
+        instance = model_class.objects.get(pk=self.app_instance.id)
+        form = form_class(data, project_pk=self.project.pk, instance=instance)
+        self.assertTrue(form.is_valid(), f"The form should be valid but has errors: {form.errors}")
+        return form
+
+    def test_update_instance_from_form_subdomain_change_aborts_when_release_not_removed(self, mock_delete, mock_deploy):
+        """A failed helm uninstall must not release the old subdomain."""
+        new_subdomain = "test-subdomain-update-app-new"
+        mock_delete.return_value = {
+            "success": False,
+            "release_missing": False,
+            "error": "Error: uninstall: timed out waiting for the condition",
+        }
+
+        form = self._subdomain_change_form(new_subdomain)
+
+        with self.assertRaises(SubdomainChangeError):
+            create_instance_from_form(form, self.project, self.app_slug, app_id=self.app_instance.id)
+
+        mock_delete.assert_called_once_with(ANY, AppActionOrigin.USER.value)
+
+        instance = DashInstance.objects.get(pk=self.app_instance.id)
+        self.assertEqual(instance.subdomain.subdomain, self.subdomain_name)
+        self.assertFalse(Subdomain.objects.filter(subdomain=new_subdomain).exists())
+        mock_deploy.assert_not_called()
+
+    def test_update_instance_from_form_subdomain_change_proceeds_when_release_missing(self, mock_delete, mock_deploy):
+        """A release that does not exist is not a delete failure, so the rename proceeds."""
+        new_subdomain = "test-subdomain-update-app-new"
+        mock_delete.return_value = {
+            "success": False,
+            "release_missing": True,
+            "error": "Error: uninstall: Release not loaded: test-subdomain-update-app: release: not found",
+        }
+
+        form = self._subdomain_change_form(new_subdomain)
+
+        with self.captureOnCommitCallbacks(execute=True):
+            create_instance_from_form(form, self.project, self.app_slug, app_id=self.app_instance.id)
+
+        instance = DashInstance.objects.get(pk=self.app_instance.id)
+        self.assertEqual(instance.subdomain.subdomain, new_subdomain)
+        mock_deploy.assert_called_once()
+
+    def test_update_instance_from_form_subdomain_change_aborts_on_unknown_delete_result(self, mock_delete, mock_deploy):
+        """Without a confirmed result the cluster cannot be assumed clean, so fail closed."""
+        new_subdomain = "test-subdomain-update-app-new"
+        mock_delete.return_value = None
+
+        form = self._subdomain_change_form(new_subdomain)
+
+        with self.assertRaises(SubdomainChangeError):
+            create_instance_from_form(form, self.project, self.app_slug, app_id=self.app_instance.id)
+
+        instance = DashInstance.objects.get(pk=self.app_instance.id)
+        self.assertEqual(instance.subdomain.subdomain, self.subdomain_name)
+        mock_deploy.assert_not_called()
 
     def test_update_instance_from_form_modify_no_redeploy_values(self, mock_delete, mock_deploy):
         """

--- a/apps/tests/test_subdomain_get_or_create.py
+++ b/apps/tests/test_subdomain_get_or_create.py
@@ -1,0 +1,84 @@
+"""Claiming a subdomain must reuse an existing row rather than attempt a duplicate insert."""
+
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from apps.app_registry import APP_REGISTRY
+from apps.helpers import create_instance_from_form
+from projects.models import Project
+
+from ..models import Apps, K8sUserAppStatus, Subdomain
+from ..models.app_types.dash import DashInstance
+
+User = get_user_model()
+
+DELETE_RESOURCE_OK = {"success": True, "release_missing": False, "error": None}
+
+
+@patch("apps.tasks.run_background_tasks.delay")
+@patch("apps.tasks.delete_resource")
+class ClaimSubdomainWithMismatchedRowTestCase(TestCase):
+    def setUp(self) -> None:
+        self.user = User.objects.create_user("foo1", "foo@test.com", "bar")
+        self.project = Project.objects.create_project(name="test-subdomain-claim", owner=self.user, description="")
+        self.app_slug = "dashapp"
+        self.app = Apps.objects.create(name="Dash App", slug=self.app_slug, user_can_delete=False)
+
+        self.subdomain_name = "test-app-subdomain"
+        self.instance = DashInstance.objects.create(
+            app=self.app,
+            access="public",
+            owner=self.user,
+            name="test-app",
+            description="description",
+            port=8000,
+            image="mock.io/test-image",
+            source_code_url="https://someurlthatdoesnotexist.com",
+            project=self.project,
+            subdomain=Subdomain.objects.create(
+                subdomain=self.subdomain_name, project=self.project, is_created_by_user=True
+            ),
+            k8s_user_app_status=K8sUserAppStatus.objects.create(),
+        )
+
+    def _save_with_subdomain(self, subdomain_name):
+        data = {
+            "name": "test-app",
+            "description": "description",
+            "access": "public",
+            "port": 8000,
+            "image": "mock.io/test-image",
+            "source_code_url": "https://someurlthatdoesnotexist.com",
+            "subdomain": subdomain_name,
+            "invenio_tags": "Antibodies|Cells",
+            "creators": '[{"name": "Test", "lastName": "User", "affiliation": "", "orcid": "", "order": 0}]',
+        }
+
+        model_class, form_class = APP_REGISTRY.get(self.app_slug)
+        instance = model_class.objects.get(pk=self.instance.pk)
+        form = form_class(data, project_pk=self.project.pk, instance=instance)
+        self.assertTrue(form.is_valid(), f"The form should be valid but has errors: {form.errors}")
+
+        with self.captureOnCommitCallbacks(execute=True):
+            create_instance_from_form(form, self.project, self.app_slug, app_id=self.instance.pk)
+
+    def test_saving_an_app_whose_row_has_no_project(self, mock_delete, mock_deploy):
+        """Subdomain.project is nullable, so a row without one must not break the app's save."""
+        Subdomain.objects.filter(pk=self.instance.subdomain.pk).update(project=None)
+
+        self._save_with_subdomain(self.subdomain_name)
+
+        self.assertEqual(Subdomain.objects.filter(subdomain=self.subdomain_name).count(), 1)
+
+    def test_claiming_a_free_row_flagged_as_auto_generated(self, mock_delete, mock_deploy):
+        """Migration 0006 backfilled is_created_by_user=False onto names users had chosen."""
+        mock_delete.return_value = DELETE_RESOURCE_OK
+        Subdomain.objects.create(subdomain="test-free-name", project=self.project, is_created_by_user=False)
+
+        self._save_with_subdomain("test-free-name")
+
+        self.assertEqual(Subdomain.objects.filter(subdomain="test-free-name").count(), 1)
+        self.instance.refresh_from_db()
+        self.assertEqual(self.instance.subdomain.subdomain, "test-free-name")

--- a/apps/types_/subdomain.py
+++ b/apps/types_/subdomain.py
@@ -5,6 +5,20 @@ from django.core.validators import RegexValidator
 
 from apps.models import BaseAppInstance, Subdomain
 
+SUBDOMAIN_RELEASE_NOT_REMOVED_MESSAGE = (
+    "The subdomain could not be changed because the current deployment of this app could not "
+    "be removed from the cluster. The subdomain was left unchanged. Please try again in a few "
+    "minutes, and contact serve@scilifelab.se if the problem persists."
+)
+
+
+class SubdomainChangeError(Exception):
+    """Raised when an app's subdomain cannot be changed without orphaning cluster resources."""
+
+    def __init__(self, message: str = SUBDOMAIN_RELEASE_NOT_REMOVED_MESSAGE):
+        self.ui_error = message
+        super().__init__(message)
+
 
 class SubdomainCandidateName:
     """

--- a/apps/views.py
+++ b/apps/views.py
@@ -28,7 +28,7 @@ from guardian.decorators import permission_required_or_403
 from rest_framework.exceptions import NotFound
 
 from apps.constants import INVENIO_RECORD_REMOVAL_REASON_LABELS, AppActionOrigin
-from apps.types_.subdomain import SubdomainCandidateName
+from apps.types_.subdomain import SubdomainCandidateName, SubdomainChangeError
 from common.auth_cache import (
     build_cache_key,
     get_cached_value,
@@ -158,6 +158,9 @@ class GetLogs(View):
         instance = self.get_instance(project, app_slug, app_id, post=True)
         if isinstance(instance, JsonResponse):
             return instance
+
+        if instance.subdomain is None:
+            return JsonResponse({"error": "This app has been deleted and no longer has logs."}, status=404)
 
         # get container name from UI (subdomain or copy-to-pvc) if none exists then use subdomain name
         container = request.POST.get("container", "") or instance.subdomain.subdomain
@@ -300,7 +303,7 @@ def delete(request, project, app_slug, app_id):
 
     serialized_instance = instance.serialize()
 
-    delete_resource.delay(serialized_instance, AppActionOrigin.USER.value)
+    delete_resource.delay(serialized_instance, AppActionOrigin.USER.value, release_subdomain=True)
 
     # fix: in case appinstance is public switch to private
     instance.access = "private"
@@ -407,6 +410,9 @@ class CreateApp(View):
             # Another request may have claimed the last GPU after this form
             # validated, check and return as a form error if needed.
             form.add_error("flavor", exc.ui_error)
+            return render_form_with_errors()
+        except SubdomainChangeError as exc:
+            form.add_error("subdomain", exc.ui_error)
             return render_form_with_errors()
         # Redirects everyone (including admins) after creation; admins can still
         # open the deployment pages (/progress, /details, /tasks) directly.


### PR DESCRIPTION
## Description

This PR relates to [SS-1433](https://scilifelab.atlassian.net/browse/SS-1433).

Changing an app's subdomain uninstalled the old Helm release and then reassigned the name regardless of whether that uninstall actually worked.

- `delete_resource` now reports whether the release is really gone. A "release: not found" error counts as gone, so apps that never deployed successfully can still be renamed.
- `handle_subdomain_change` only gives up the old subdomain on a confirmed removal. Otherwise it raises `SubdomainChangeError`, the atomic transaction rolls the whole update back, and the user gets an error on the subdomain field rather than an app that points at nothing.
- Deleting an app now hands its subdomain back once the uninstall is confirmed, so the name becomes available again. Volumes and netpolicy are excluded, since apps that mount a volume still read its subdomain.
- Separately, `Subdomain.objects.get_or_create` looked up on `subdomain`, `project` and `is_created_by_user`, but only `subdomain` is unique. A row with a different project or flag missed the lookup and then failed to insert, raising IntegrityError instead of being reused. It now looks up on the unique field with the rest as defaults.

## Checklist

- [x] This pull request is against **develop** branch (not applicable for hotfixes)
- [x] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [x] I have added or updated unit and end2end tests or a manual test case to complement my changes
- [ ] I have ran unit and end2end tests
- [x] I have considered accessibility for UI changes and reviewed pre-commit/Pa11y results or documented a manual check
- [ ] I have updated the related documentation (if necessary)
- [x] I have added a reviewer for this pull request
- [x] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts
- [ ] In case your changes are large enough, did you deploy your changes to develop instance?