### PR TITLE
SS-1486 Maintenance mode error fix

### DIFF
--- a/common/templatetags/is_login_signup_disabled.py
+++ b/common/templatetags/is_login_signup_disabled.py
@@ -5,5 +5,8 @@ register = template.Library()
 
 @register.filter(name="is_login_signup_disabled")
 def is_login_signup_disabled(items):
-    # `items` may be a QuerySet or a cached list (see common.context_processors)
+    # `items` may be None, a QuerySet, or a cached list (see common.context_processors)
+    if items is None:
+        return False
+
     return any(obj.login_and_signup_disabled for obj in items)

--- a/common/tests/test_is_login_signup_disabled.py
+++ b/common/tests/test_is_login_signup_disabled.py
@@ -1,0 +1,25 @@
+from types import SimpleNamespace
+
+import pytest
+
+from common.templatetags.is_login_signup_disabled import is_login_signup_disabled
+
+
+@pytest.mark.parametrize("items", [None, []])
+def test_is_login_signup_disabled_returns_false_for_missing_items(items):
+    assert is_login_signup_disabled(items) is False
+
+
+def test_is_login_signup_disabled_returns_false_when_all_items_are_enabled():
+    items = [SimpleNamespace(login_and_signup_disabled=False)]
+
+    assert is_login_signup_disabled(items) is False
+
+
+def test_is_login_signup_disabled_returns_true_when_an_item_disables_login_and_signup():
+    items = [
+        SimpleNamespace(login_and_signup_disabled=False),
+        SimpleNamespace(login_and_signup_disabled=True),
+    ]
+
+    assert is_login_signup_disabled(items) is True


### PR DESCRIPTION
## Description

This PR relates to [SS-1486](https://scilifelab.atlassian.net/browse/SS-1486).

The `is_login_signup_disabled` template filter now returns `False` when maintenance-mode data is missing. This prevents a secondary template exception if the filter receives `None` while preserving the existing behavior for querysets and cached lists.

## Checklist

> If you're unsure about any of the items below, don't hesitate to ask. We're here to help!
> This is simply a reminder of what we are going to look for before merging your code.

- [x] This pull request is against **develop** branch (not applicable for hotfixes)
- [x] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [x] I have added or updated unit and end2end tests or a manual test case to complement my changes
- [ ] I have ran unit and end2end tests
- [x] I have considered accessibility for UI changes and reviewed pre-commit/Pa11y results or documented a manual check
- [ ] I have updated the related documentation (if necessary)
- [x] I have added a reviewer for this pull request
- [x] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts
- [ ] In case your changes are large enough, did you deploy your changes to develop instance?