### PR TITLE
SS-1996 service label character limit

### DIFF
--- a/apps/models/app_types/shiny.py
+++ b/apps/models/app_types/shiny.py
@@ -64,6 +64,8 @@ class ShinyInstance(BaseAppInstance, SocialMixin, LogsEnabledMixin):
     def get_k8s_values(self):
         k8s_values = super().get_k8s_values()
 
+        # Set appname as runLabel.
+        k8s_values["service"]["runLabel"] = k8s_values["appname"]
         k8s_values["permission"] = str(self.access)
         k8s_values["appconfig"] = dict(
             port=self.port,

--- a/apps/tests/test_app_instance.py
+++ b/apps/tests/test_app_instance.py
@@ -155,6 +155,42 @@ class AppInstanceStatusTestCase(TestCase):
         self.assertEqual(app_instance.get_status_group(), "danger")
 
 
+class ShinyK8sValuesTestCase(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user("shiny-user", "shiny@test.com", "password")
+        self.project = Project.objects.create_project(name="Shiny project", owner=self.user, description="")
+        self.app = Apps.objects.create(name="Shiny", slug="shiny", chart="shinyproxy")
+
+    def test_service_run_label_uses_maximum_length_subdomain(self):
+        subdomain_name = "a" * 53
+        instance = ShinyInstance.objects.create(
+            owner=self.user,
+            name="Shiny app",
+            app=self.app,
+            chart="shinyproxy",
+            project=self.project,
+            subdomain=Subdomain.objects.create(subdomain=subdomain_name),
+            image="example/shiny:latest",
+        )
+
+        k8s_values = instance.get_k8s_values()
+
+        self.assertEqual(k8s_values["service"]["runLabel"], subdomain_name)
+        self.assertLessEqual(len(k8s_values["service"]["runLabel"]), 63)
+
+    def test_service_run_label_is_not_added_to_other_app_types(self):
+        instance = BaseAppInstance.objects.create(
+            owner=self.user,
+            name="Other app",
+            app=self.app,
+            chart="other-chart",
+            project=self.project,
+            subdomain=Subdomain.objects.create(subdomain="other-app"),
+        )
+
+        self.assertNotIn("runLabel", instance.get_k8s_values()["service"])
+
+
 @pytest.mark.parametrize(
     "latest_user_action, k8s_user_app_status, expected",
     [


### PR DESCRIPTION
## Description

This PR relates to [SS-1996](https://scilifelab.atlassian.net/browse/SS-1996).

Shiny deployments with long subdomains could fail because the ShinyProxy chart generated a Kubernetes label longer than 63 characters.

- Sets `service.runLabel` to the validated `appname` value for Shiny instances.
- Adds tests covering a maximum-length subdomain

## Checklist

> If you're unsure about any of the items below, don't hesitate to ask. We're here to help!
> This is simply a reminder of what we are going to look for before merging your code.

- [x] This pull request is against **develop** branch (not applicable for hotfixes)
- [x] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [x] I have added or updated unit and end2end tests or a manual test case to complement my changes
- [ ] I have ran unit and end2end tests
- [x] I have considered accessibility for UI changes and reviewed pre-commit/Pa11y results or documented a manual check
- [ ] I have updated the related documentation (if necessary)
- [x] I have added a reviewer for this pull request
- [x] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts
- [ ] In case your changes are large enough, did you deploy your changes to develop instance?