### PR TITLE
SS-2000 Introduce an endpoint for the liveness probe

### DIFF
--- a/studio/db_pool.py
+++ b/studio/db_pool.py
@@ -40,3 +40,11 @@ def db_pool_stats_changed(
 ) -> tuple[bool, dict[str, Any]]:
     current_stats = {key: stats.get(key) for key in DB_POOL_STATS_CHANGE_KEYS}
     return previous_stats != current_stats, current_stats
+
+
+def is_pool_saturated(alias: str = "default") -> bool:
+    """True if every pooled connection is checked out and a request is currently waiting for one."""
+    stats = get_db_pool_stats(alias)
+    if not stats.get("enabled") or not stats.get("opened"):
+        return False
+    return bool(stats.get("pool_available", 0) == 0 and stats.get("requests_waiting", 0) > 0)

--- a/studio/urls.py
+++ b/studio/urls.py
@@ -47,6 +47,7 @@ urlpatterns = (
             name="delete_account_post_handler",
         ),
         path("status", views.status_view, name="status"),
+        path("status/liveness", views.liveness_view, name="liveness"),
         re_path(r"^metrics/?$", metrics_view, name="metrics"),
         path("user/account-deleted/<int:user_id>", views.account_deleted, name="account_deleted"),
         path("auth/", views.AuthView.as_view()),

--- a/studio/views.py
+++ b/studio/views.py
@@ -32,6 +32,7 @@ from studio.auth_permission_cache import (
     is_auth_permission_cache_enabled,
     set_cached_auth_permission,
 )
+from studio.db_pool import is_pool_saturated
 from studio.throttle import WhitelistThrottleFilter
 from studio.utils import get_logger
 
@@ -301,4 +302,16 @@ def __get_university_name(request: Response, code: str) -> str:
 
 def status_view(request: HttpRequest) -> HttpResponse:
     """Health check endpoint returning JSON status."""
+    return JsonResponse({"status": "ok"})
+
+
+def liveness_view(request: HttpRequest) -> HttpResponse:
+    """
+    Liveness probe endpoint.
+
+    Reports 503 when the DB connection pool is saturated.
+    Allows restarting the pod if the connection pool remains saturated.
+    """
+    if is_pool_saturated():
+        return JsonResponse({"status": "degraded", "reason": "db_pool_saturated"}, status=503)
     return JsonResponse({"status": "ok"})


### PR DESCRIPTION
## Description

Jira: https://scilifelab.atlassian.net/browse/SS-2000

Introduce an endpoint to check if Serve's connection pool is saturated. Wire this endpoint to the liveness probe so that the pod gets automatically restarted after ~ 5 minutes.

## TODO

- [x] works locally using Helm
- [x] works on Serve dev

## Checklist

> If you're unsure about any of the items below, don't hesitate to ask. We're here to help!
> This is simply a reminder of what we are going to look for before merging your code.

- [X] This pull request is against **develop** branch (not applicable for hotfixes)
- [X] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [ ] I have added or updated unit and end2end tests or a manual test case to complement my changes
- [ ] I have ran unit and end2end tests
- [ ] I have considered accessibility for UI changes and reviewed pre-commit/Pa11y results or documented a manual check
- [ ] I have updated the related documentation (if necessary)
- [X] I have added a reviewer for this pull request
- [X] I have added myself as an author for this pull request
- [X] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts
- [ ] In case your changes are large enough, did you deploy your changes to develop instance?

# PR cheatsheet

- PR -- pull request
- Include jira ticket in the PR title (like `SS-1234 Introduced machine learning ai driven framework for DDLS Fellows from EMBL`)
- To set the status of the pull request, use the built-in github feature to set the PR as Draft or Ready for review.
- To indicate the type of change (such as bugfix or new feature), use a github pull request label.
- If pr is not ready for review, set it draft. We agreed in the team, that if the PR in the draft state, no one will review it.
- Remember, that you can trigger end2end tests manually
