### PR TITLE
SS-1744 bump shinyproxy version

### DIFF
--- a/apps/tests/test_kubernetes_deployment_manifest.py
+++ b/apps/tests/test_kubernetes_deployment_manifest.py
@@ -85,7 +85,7 @@ class ValidKubernetesDeploymentManifestTestCase(TestCase):
         chart = "oci://ghcr.io/scilifelabdatacentre/serve-charts/shinyproxy"
         values_file, _ = self.kdm.get_filepaths()
         namespace = "default"
-        version = "1.4.2"
+        version = "1.4.12"
 
         output, error = self.kdm.generate_manifest_yaml_from_template(
             chart, values_file, namespace, version, save_to_file=False
@@ -107,7 +107,7 @@ class ValidKubernetesDeploymentManifestTestCase(TestCase):
         chart = "oci://ghcr.io/scilifelabdatacentre/serve-charts/shinyproxy"
         values_file, _ = self.kdm.get_filepaths()
         namespace = "default"
-        version = "1.4.2"
+        version = "1.4.12"
 
         output, error = self.kdm.generate_manifest_yaml_from_template(
             chart, values_file, namespace, version, save_to_file=False
@@ -135,7 +135,7 @@ class ValidKubernetesDeploymentManifestTestCase(TestCase):
         chart = "oci://ghcr.io/scilifelabdatacentre/serve-charts/shinyproxy"
         values_file, _ = self.kdm.get_filepaths()
         namespace = "default"
-        version = "1.4.2"
+        version = "1.4.12"
 
         output, error = self.kdm.generate_manifest_yaml_from_template(
             chart, values_file, namespace, version, save_to_file=False

--- a/apps/tests/test_kubernetes_deployment_manifest.py
+++ b/apps/tests/test_kubernetes_deployment_manifest.py
@@ -13,6 +13,8 @@ class ValidKubernetesDeploymentManifestTestCase(TestCase):
     DEPLOYMENT_ID = "unittest-valid"
 
     VALUES_DATA = r"""
+        gateway:
+            enabled: false
         appconfig:
             allowContainerReuse: false
             image: ghcr.io/somerepo/shiny:v1

--- a/fixtures/apps_fixtures.json
+++ b/fixtures/apps_fixtures.json
@@ -290,7 +290,7 @@
   {
     "fields": {
       "category": "serve",
-      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/shinyproxy:1.4.10",
+      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/shinyproxy:1.4.12",
       "created_on": "2023-08-25T21:34:37.815Z",
       "description": "",
       "logo": "shinyapp-logo.svg",


### PR DESCRIPTION
## Description

This PR relates to [SS-1744](https://scilifelab.atlassian.net/browse/SS-1744).

It updates Serve to use ShinyProxy chart `1.4.12`:

- updates the Shiny app fixture from chart `1.4.10` to `1.4.12`, so newly created Shiny instances use the new chart
- updates the Kubernetes deployment manifest tests from chart `1.4.2` to `1.4.12`

## Checklist

> If you're unsure about any of the items below, don't hesitate to ask. We're here to help!
> This is simply a reminder of what we are going to look for before merging your code.

- [x] This pull request is against **develop** branch (not applicable for hotfixes)
- [x] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [x] I have added or updated unit and end2end tests or a manual test case to complement my changes
- [ ] I have ran unit and end2end tests
- [x] I have considered accessibility for UI changes and reviewed pre-commit/Pa11y results or documented a manual check
- [ ] I have updated the related documentation (if necessary)
- [x] I have added a reviewer for this pull request
- [x] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts
- [ ] In case your changes are large enough, did you deploy your changes to develop instance?