### PR TITLE
SS-1994 limit service name length

### DIFF
--- a/apps/models/app_types/shiny.py
+++ b/apps/models/app_types/shiny.py
@@ -64,8 +64,6 @@ class ShinyInstance(BaseAppInstance, SocialMixin, LogsEnabledMixin):
     def get_k8s_values(self):
         k8s_values = super().get_k8s_values()
 
-        # Set appname as runLabel.
-        k8s_values["service"]["runLabel"] = k8s_values["appname"]
         k8s_values["permission"] = str(self.access)
         k8s_values["appconfig"] = dict(
             port=self.port,

--- a/apps/models/base/base.py
+++ b/apps/models/base/base.py
@@ -15,6 +15,8 @@ from studio.utils import get_logger
 
 logger = get_logger(__name__)
 
+DNS_LABEL_MAX_LENGTH = 63
+
 USER_ACTION_STATUS_CHOICES = [
     ("Creating", "Creating"),
     ("Changing", "Changing"),
@@ -279,12 +281,16 @@ class BaseAppInstance(models.Model):
         return f"{self.name}-{self.owner}-{self.app.name}-{self.project}"
 
     def get_k8s_values(self):
+        appname = self.subdomain.subdomain if self.subdomain else "deleted"
+        service_name = f"{appname}-{self.app.slug}"[:DNS_LABEL_MAX_LENGTH].rstrip("-")
+
         k8s_values = dict(
             name=self.name,
-            appname=self.subdomain.subdomain if self.subdomain else "deleted",
+            appname=appname,
             project=dict(name=self.project.name, slug=self.project.slug),
             service=dict(
-                name=(self.subdomain.subdomain if self.subdomain else "deleted") + "-" + self.app.slug,
+                name=service_name,
+                runLabel=appname,
             ),
             **self.subdomain.to_dict() if self.subdomain else {},
             **self.flavor.to_dict(self.app.gpu_enabled) if self.flavor else {},

--- a/apps/tests/test_app_instance.py
+++ b/apps/tests/test_app_instance.py
@@ -155,7 +155,7 @@ class AppInstanceStatusTestCase(TestCase):
         self.assertEqual(app_instance.get_status_group(), "danger")
 
 
-class ShinyK8sValuesTestCase(TestCase):
+class K8sValuesNameLengthTestCase(TestCase):
     def setUp(self):
         self.user = User.objects.create_user("shiny-user", "shiny@test.com", "password")
         self.project = Project.objects.create_project(name="Shiny project", owner=self.user, description="")
@@ -178,7 +178,24 @@ class ShinyK8sValuesTestCase(TestCase):
         self.assertEqual(k8s_values["service"]["runLabel"], subdomain_name)
         self.assertLessEqual(len(k8s_values["service"]["runLabel"]), 63)
 
-    def test_service_run_label_is_not_added_to_other_app_types(self):
+    def test_service_name_is_truncated_to_kubernetes_limit(self):
+        subdomain_name = "a" * 53
+        instance = ShinyInstance.objects.create(
+            owner=self.user,
+            name="ShinyProxy app",
+            app=Apps.objects.create(name="ShinyProxy", slug="shinyproxyapp", chart="shinyproxy"),
+            chart="shinyproxy",
+            project=self.project,
+            subdomain=Subdomain.objects.create(subdomain=subdomain_name),
+            image="example/shiny:latest",
+        )
+
+        service_name = instance.get_k8s_values()["service"]["name"]
+
+        self.assertEqual(service_name, f"{subdomain_name}-shinyproxyapp"[:63])
+        self.assertEqual(len(service_name), 63)
+
+    def test_service_run_label_is_added_to_other_app_types(self):
         instance = BaseAppInstance.objects.create(
             owner=self.user,
             name="Other app",
@@ -188,7 +205,7 @@ class ShinyK8sValuesTestCase(TestCase):
             subdomain=Subdomain.objects.create(subdomain="other-app"),
         )
 
-        self.assertNotIn("runLabel", instance.get_k8s_values()["service"])
+        self.assertEqual(instance.get_k8s_values()["service"]["runLabel"], "other-app")
 
 
 @pytest.mark.parametrize(

--- a/fixtures/apps_fixtures.json
+++ b/fixtures/apps_fixtures.json
@@ -2,7 +2,7 @@
   {
     "fields": {
       "category": "develop",
-      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/lab:1.0.11",
+      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/lab:1.0.10",
       "created_on": "2021-02-19T21:34:37.815Z",
       "description": "",
       "gpu_enabled": true,
@@ -21,7 +21,7 @@
   {
     "fields": {
       "category": "manage-files",
-      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/filemanager:1.0.10",
+      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/filemanager:1.0.9",
       "created_on": "2021-02-19T21:34:37.815Z",
       "description": "",
       "logo": "filemanager-logo.svg",
@@ -176,7 +176,7 @@
   {
     "fields": {
       "category": "develop",
-      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/vscode:1.0.9",
+      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/vscode:1.0.8",
       "created_on": "2025-03-12T12:10:37.815Z",
       "description": "",
       "gpu_enabled": true,
@@ -215,7 +215,7 @@
   {
     "fields": {
       "category": "serve",
-      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/custom-app:1.1.8",
+      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/custom-app:1.1.7",
       "created_on": "2023-08-25T21:34:37.815Z",
       "description": "Apps built with Gradio, Streamlit, Flask, etc.",
       "gpu_enabled": true,
@@ -234,7 +234,7 @@
   {
     "fields": {
       "category": "develop",
-      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/rstudio:1.0.10",
+      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/rstudio:1.0.9",
       "created_on": "2023-08-31T09:30:00.000Z",
       "description": "",
       "gpu_enabled": true,
@@ -253,7 +253,7 @@
   {
     "fields": {
       "category": "serve",
-      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/dash-app:1.0.9",
+      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/dash-app:1.0.8",
       "created_on": "2023-08-25T21:34:37.815Z",
       "description": "",
       "gpu_enabled": true,
@@ -272,7 +272,7 @@
   {
     "fields": {
       "category": "serve",
-      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/shinyapp:1.0.10",
+      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/shinyapp:1.0.9",
       "created_on": "2023-08-25T21:34:37.815Z",
       "description": "",
       "logo": "shinyapp-logo.svg",
@@ -377,7 +377,7 @@
   {
     "fields": {
       "category": "serve",
-      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/tissuumaps:1.0.9",
+      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/tissuumaps:1.0.8",
       "created_on": "2023-08-25T21:34:37.815Z",
       "description": "App to visualise and explore data using TissUUmaps.",
       "logo": "tissuumaps-logo.svg",
@@ -395,7 +395,7 @@
   {
     "fields": {
       "category": "serve",
-      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/custom-app:1.1.8",
+      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/custom-app:1.1.7",
       "created_on": "2023-08-25T21:34:37.815Z",
       "description": "",
       "gpu_enabled": true,
@@ -414,7 +414,7 @@
   {
     "fields": {
       "category": "serve",
-      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/custom-app:1.1.8",
+      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/custom-app:1.1.7",
       "created_on": "2023-08-25T21:34:37.815Z",
       "description": "",
       "gpu_enabled": true,

--- a/fixtures/apps_fixtures.json
+++ b/fixtures/apps_fixtures.json
@@ -2,7 +2,7 @@
   {
     "fields": {
       "category": "develop",
-      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/lab:1.0.10",
+      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/lab:1.0.11",
       "created_on": "2021-02-19T21:34:37.815Z",
       "description": "",
       "gpu_enabled": true,
@@ -21,7 +21,7 @@
   {
     "fields": {
       "category": "manage-files",
-      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/filemanager:1.0.9",
+      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/filemanager:1.0.10",
       "created_on": "2021-02-19T21:34:37.815Z",
       "description": "",
       "logo": "filemanager-logo.svg",
@@ -176,7 +176,7 @@
   {
     "fields": {
       "category": "develop",
-      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/vscode:1.0.8",
+      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/vscode:1.0.9",
       "created_on": "2025-03-12T12:10:37.815Z",
       "description": "",
       "gpu_enabled": true,
@@ -215,7 +215,7 @@
   {
     "fields": {
       "category": "serve",
-      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/custom-app:1.1.7",
+      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/custom-app:1.1.8",
       "created_on": "2023-08-25T21:34:37.815Z",
       "description": "Apps built with Gradio, Streamlit, Flask, etc.",
       "gpu_enabled": true,
@@ -234,7 +234,7 @@
   {
     "fields": {
       "category": "develop",
-      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/rstudio:1.0.9",
+      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/rstudio:1.0.10",
       "created_on": "2023-08-31T09:30:00.000Z",
       "description": "",
       "gpu_enabled": true,
@@ -253,7 +253,7 @@
   {
     "fields": {
       "category": "serve",
-      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/dash-app:1.0.8",
+      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/dash-app:1.0.9",
       "created_on": "2023-08-25T21:34:37.815Z",
       "description": "",
       "gpu_enabled": true,
@@ -272,7 +272,7 @@
   {
     "fields": {
       "category": "serve",
-      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/shinyapp:1.0.9",
+      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/shinyapp:1.0.10",
       "created_on": "2023-08-25T21:34:37.815Z",
       "description": "",
       "logo": "shinyapp-logo.svg",
@@ -290,7 +290,7 @@
   {
     "fields": {
       "category": "serve",
-      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/shinyproxy:1.4.10",
+      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/shinyproxy:1.4.12",
       "created_on": "2023-08-25T21:34:37.815Z",
       "description": "",
       "logo": "shinyapp-logo.svg",
@@ -377,7 +377,7 @@
   {
     "fields": {
       "category": "serve",
-      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/tissuumaps:1.0.8",
+      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/tissuumaps:1.0.9",
       "created_on": "2023-08-25T21:34:37.815Z",
       "description": "App to visualise and explore data using TissUUmaps.",
       "logo": "tissuumaps-logo.svg",
@@ -395,7 +395,7 @@
   {
     "fields": {
       "category": "serve",
-      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/custom-app:1.1.7",
+      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/custom-app:1.1.8",
       "created_on": "2023-08-25T21:34:37.815Z",
       "description": "",
       "gpu_enabled": true,
@@ -414,7 +414,7 @@
   {
     "fields": {
       "category": "serve",
-      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/custom-app:1.1.7",
+      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/custom-app:1.1.8",
       "created_on": "2023-08-25T21:34:37.815Z",
       "description": "",
       "gpu_enabled": true,

--- a/fixtures/projects_templates.json
+++ b/fixtures/projects_templates.json
@@ -28,7 +28,7 @@
         "environments": {
           "Jupyter Lab Minimal (Default)": {
             "app": "jupyter-lab",
-            "image": "serve-jupyterlab-minimal:250213-1113",
+            "image": "serve-jupyterlab-minimal:260825-1814",
             "repository": "ghcr.io/scilifelabdatacentre"
           },
           "Jupyter Lab Data Science": {
@@ -38,17 +38,17 @@
           },
           "Jupyter Lab PyTorch": {
             "app": "jupyter-lab",
-            "image": "serve-jupyterlab-pytorch:250213-1119",
+            "image": "serve-jupyterlab-pytorch:260825-1816",
             "repository": "ghcr.io/scilifelabdatacentre"
           },
           "Jupyter Lab Tensorflow": {
             "app": "jupyter-lab",
-            "image": "serve-jupyterlab-tensorflow:250213-1120",
+            "image": "serve-jupyterlab-tensorflow:260825-1818",
             "repository": "ghcr.io/scilifelabdatacentre"
           },
           "Default RStudio": {
             "app": "rstudio",
-            "image": "serve-rstudio:250304-1611",
+            "image": "serve-rstudio:260825-1821",
             "repository": "ghcr.io/scilifelabdatacentre"
           }
         },


### PR DESCRIPTION
## Description

This PR relates to [SS-1994](https://scilifelab.atlassian.net/browse/SS-1994).

This fixes app deployments that failed when long subdomains produced Kubernetes Service names or labels exceeding the 63-character DNS-label limit.

- Sets `service.runLabel` for every app type instead of handling Shiny separately.
- Limits generated Service names to 63 characters while preserving the complete, unique subdomain.
- Updates the app fixtures.

> If you're unsure about any of the items below, don't hesitate to ask. We're here to help!
> This is simply a reminder of what we are going to look for before merging your code.

- [x] This pull request is against **develop** branch (not applicable for hotfixes)
- [x] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [x] I have added or updated unit and end2end tests or a manual test case to complement my changes
- [ ] I have ran unit and end2end tests
- [x] I have considered accessibility for UI changes and reviewed pre-commit/Pa11y results or documented a manual check
- [ ] I have updated the related documentation (if necessary)
- [x] I have added a reviewer for this pull request
- [x] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts
- [ ] In case your changes are large enough, did you deploy your changes to develop instance?